### PR TITLE
Update `extract-tagged-template-literals` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@glimmer/syntax": "^0.39.3",
     "ast-types": "^0.11.3",
     "ember-meta-explorer": "^0.0.11",
-    "extract-tagged-template-literals": "^1.0.0",
+    "extract-tagged-template-literals": "^1.0.1",
     "fs-extra": "^5.0.0",
     "fuzzaldrin": "^2.1.0",
     "i": "^0.3.5",


### PR DESCRIPTION
Fix the no-trailing-spaces ember-template-lint error for inline templates inside ts/js files.