### PR TITLE
fix incorrect visit invocation

### DIFF
--- a/src/symbols/hbs-document-symbol-provider.ts
+++ b/src/symbols/hbs-document-symbol-provider.ts
@@ -1,55 +1,58 @@
 import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
 import { preprocess, traverse } from '@glimmer/syntax';
-
+import { log } from './../utils/logger';
 import DocumentSymbolProvider from './document-symbol-provider';
 import { toLSRange } from '../estree-utils';
 
 export default class HBSDocumentSymbolProvider implements DocumentSymbolProvider {
   extensions: string[] = ['.hbs'];
-
   process(content: string): SymbolInformation[] {
-    let ast = preprocess(content);
-
     let symbols: SymbolInformation[] = [];
 
-    traverse(ast, {
-      ElementNode(node: any) {
-        if (node.tag.charAt(0) === node.tag.charAt(0).toUpperCase()) {
-          symbols.push(SymbolInformation.create(node.tag, SymbolKind.Variable, toLSRange(node.loc)));
-        }
-      },
-      BlockStatement(node: any) {
-        if (node.hash.pairs.length) {
-          node.hash.pairs
-            .filter((el: any) => el.type === 'HashPair')
-            .forEach((pair: any) => {
-              symbols.push(SymbolInformation.create(pair.key, SymbolKind.Property, toLSRange(pair.loc)));
-            });
-        }
+    try {
+      let ast = preprocess(content);
 
-        if (node.program.blockParams.length === 0) return;
+      traverse(ast, {
+        ElementNode(node: any) {
+          if (node.tag.charAt(0) === node.tag.charAt(0).toUpperCase()) {
+            symbols.push(SymbolInformation.create(node.tag, SymbolKind.Variable, toLSRange(node.loc)));
+          }
+        },
+        BlockStatement(node: any) {
+          if (node.hash.pairs.length) {
+            node.hash.pairs
+              .filter((el: any) => el.type === 'HashPair')
+              .forEach((pair: any) => {
+                symbols.push(SymbolInformation.create(pair.key, SymbolKind.Property, toLSRange(pair.loc)));
+              });
+          }
 
-        node.program.blockParams.forEach((blockParam: string) => {
-          let symbol = SymbolInformation.create(blockParam, SymbolKind.Variable, toLSRange(node.loc));
-          symbols.push(symbol);
-        });
-      },
-      MustacheStatement(node: any) {
-        if (node.hash.pairs.length) {
-          node.hash.pairs
-            .filter((el: any) => el.type === 'HashPair')
-            .forEach((pair: any) => {
-              symbols.push(SymbolInformation.create(pair.key, SymbolKind.Property, toLSRange(pair.loc)));
-            });
-        }
-        if (node.path.type === 'PathExpression') {
-          if (node.path.data) {
-            let symbol = SymbolInformation.create(node.path.original, SymbolKind.Variable, toLSRange(node.path.loc));
+          if (node.program.blockParams.length === 0) return;
+
+          node.program.blockParams.forEach((blockParam: string) => {
+            let symbol = SymbolInformation.create(blockParam, SymbolKind.Variable, toLSRange(node.loc));
             symbols.push(symbol);
+          });
+        },
+        MustacheStatement(node: any) {
+          if (node.hash.pairs.length) {
+            node.hash.pairs
+              .filter((el: any) => el.type === 'HashPair')
+              .forEach((pair: any) => {
+                symbols.push(SymbolInformation.create(pair.key, SymbolKind.Property, toLSRange(pair.loc)));
+              });
+          }
+          if (node.path.type === 'PathExpression') {
+            if (node.path.data) {
+              let symbol = SymbolInformation.create(node.path.original, SymbolKind.Variable, toLSRange(node.path.loc));
+              symbols.push(symbol);
+            }
           }
         }
-      }
-    });
+      });
+    } catch (e) {
+      log('symbolprovider:template:error', e, e.toString(), e.stack);
+    }
 
     return symbols;
   }

--- a/src/symbols/js-document-symbol-provider.ts
+++ b/src/symbols/js-document-symbol-provider.ts
@@ -2,27 +2,31 @@ import { SymbolInformation, SymbolKind } from 'vscode-languageserver';
 import { parseScriptFile as parse } from 'ember-meta-explorer';
 import DocumentSymbolProvider from './document-symbol-provider';
 import { toLSRange } from '../estree-utils';
-
+import { log } from './../utils/logger';
 import { visit } from 'ast-types';
 
 export default class JSDocumentSymbolProvider implements DocumentSymbolProvider {
   extensions: string[] = ['.js'];
 
   process(content: string): SymbolInformation[] {
-    const ast = parse(content);
-
     let symbols: SymbolInformation[] = [];
 
-    visit(ast, {
-      visitProperty(path: any) {
-        let node = path.node;
+    try {
+      const ast = parse(content);
 
-        let symbol = SymbolInformation.create(node.key.name, SymbolKind.Property, toLSRange(node.key.loc));
-        symbols.push(symbol);
+      visit(ast, {
+        visitProperty(path: any) {
+          let node = path.node;
 
-        this.traverse(path);
-      }
-    });
+          let symbol = SymbolInformation.create(node.key.name, SymbolKind.Property, toLSRange(node.key.loc));
+          symbols.push(symbol);
+
+          this.traverse(path);
+        }
+      });
+    } catch (e) {
+      log('symbolprovider:script:error', e, e.toString(), e.stack);
+    }
 
     return symbols;
   }

--- a/src/symbols/js-document-symbol-provider.ts
+++ b/src/symbols/js-document-symbol-provider.ts
@@ -3,7 +3,7 @@ import { parseScriptFile as parse } from 'ember-meta-explorer';
 import DocumentSymbolProvider from './document-symbol-provider';
 import { toLSRange } from '../estree-utils';
 
-import types from 'ast-types';
+import { visit } from 'ast-types';
 
 export default class JSDocumentSymbolProvider implements DocumentSymbolProvider {
   extensions: string[] = ['.js'];
@@ -13,7 +13,7 @@ export default class JSDocumentSymbolProvider implements DocumentSymbolProvider 
 
     let symbols: SymbolInformation[] = [];
 
-    types.visit(ast, {
+    visit(ast, {
       visitProperty(path: any) {
         let node = path.node;
 

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -2158,6 +2158,8 @@ Array [
 
 exports[`integration DocumentSymbolProvider able to provide symbols for script document 1`] = `Array []`;
 
+exports[`integration DocumentSymbolProvider stable if ast broken in script document 1`] = `Array []`;
+
 exports[`integration GlimmerNative able to provide glimmer-native component 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -2156,6 +2156,8 @@ Array [
 ]
 `;
 
+exports[`integration DocumentSymbolProvider able to provide symbols for script document 1`] = `Array []`;
+
 exports[`integration GlimmerNative able to provide glimmer-native component 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -2158,7 +2158,11 @@ Array [
 
 exports[`integration DocumentSymbolProvider able to provide symbols for script document 1`] = `Array []`;
 
+exports[`integration DocumentSymbolProvider able to provide symbols for template document 1`] = `Array []`;
+
 exports[`integration DocumentSymbolProvider stable if ast broken in script document 1`] = `Array []`;
+
+exports[`integration DocumentSymbolProvider stable if ast broken in template document 1`] = `Array []`;
 
 exports[`integration GlimmerNative able to provide glimmer-native component 1`] = `
 Array [

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -494,6 +494,23 @@ describe('integration', function() {
 
       expect(result).toMatchSnapshot();
     });
+    it('able to provide symbols for template document', async () => {
+      const result = await getResult(
+        DocumentSymbolRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.hbs': '{{this.foo}}'
+            }
+          }
+        },
+        'app/components/hello.hbs',
+        { line: 0, character: 1 }
+      );
+
+      expect(result).toMatchSnapshot();
+    });
     it('stable if ast broken in script document', async () => {
       const result = await getResult(
         DocumentSymbolRequest.type,
@@ -506,6 +523,23 @@ describe('integration', function() {
           }
         },
         'app/components/hello.js',
+        { line: 0, character: 1 }
+      );
+
+      expect(result).toMatchSnapshot();
+    });
+    it('stable if ast broken in template document', async () => {
+      const result = await getResult(
+        DocumentSymbolRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.hbs': '{{'
+            }
+          }
+        },
+        'app/components/hello.hbs',
         { line: 0, character: 1 }
       );
 

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -494,6 +494,23 @@ describe('integration', function() {
 
       expect(result).toMatchSnapshot();
     });
+    it('stable if ast broken in script document', async () => {
+      const result = await getResult(
+        DocumentSymbolRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.js': 'export default class Foo {'
+            }
+          }
+        },
+        'app/components/hello.js',
+        { line: 0, character: 1 }
+      );
+
+      expect(result).toMatchSnapshot();
+    });
   });
 
   describe('GlimmerNative', () => {

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -9,6 +9,7 @@ import {
   InitializeRequest,
   CompletionRequest,
   DefinitionRequest,
+  DocumentSymbolRequest,
   ExecuteCommandRequest,
   Definition,
   ReferencesRequest
@@ -471,6 +472,26 @@ describe('integration', function() {
         'App.js',
         { line: 0, character: 20 }
       );
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('DocumentSymbolProvider', () => {
+    it('able to provide symbols for script document', async () => {
+      const result = await getResult(
+        DocumentSymbolRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.js': 'export default class Foo {}'
+            }
+          }
+        },
+        'app/components/hello.js',
+        { line: 0, character: 1 }
+      );
+
       expect(result).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
fixes

```
[Error - 7:21:25 PM] Request textDocument/documentSymbol failed.
  Message: Request textDocument/documentSymbol failed with message: Cannot read property 'visit' of undefined
  Code: -32603 
```

// @knownasilya

ref: https://github.com/lifeart/ember-language-server/issues/12#issuecomment-560033096