### PR TITLE
scoped-block-params-autocomplete

### DIFF
--- a/src/builtin-addons/core/template-completion-provider.ts
+++ b/src/builtin-addons/core/template-completion-provider.ts
@@ -138,9 +138,8 @@ export default class TemplateCompletionProvider {
     return originalText.slice(0, offset) + PLACEHOLDER + originalText.slice(offset);
   }
   getScopedValues(focusPath: ASTPath) {
-    const scopedValues = getLocalScope(focusPath).map(([name, fPath]) => {
-      const blockSource =
-        fPath.node.type === 'ElementNode' ? `<${fPath.node.tag} as |...|>` : `{{#${fPath.parentPath && fPath.parentPath.node.path.original} as |...|}}`;
+    const scopedValues = getLocalScope(focusPath).map(({ name, node, path }) => {
+      const blockSource = node.type === 'ElementNode' ? `<${node.tag} as |...|>` : `{{#${path.parentPath && path.parentPath.node.path.original} as |...|}}`;
       return {
         label: name,
         kind: CompletionItemKind.Variable,

--- a/src/completion-provider/script-completion-provider.ts
+++ b/src/completion-provider/script-completion-provider.ts
@@ -35,7 +35,7 @@ export default class ScriptCompletionProvider {
       return [];
     }
 
-    const focusPath = ASTPath.toPosition(ast, toPosition(params.position));
+    const focusPath = ASTPath.toPosition(ast, toPosition(params.position), content);
 
     if (!focusPath || !project || !document) {
       return [];

--- a/src/completion-provider/template-completion-provider.ts
+++ b/src/completion-provider/template-completion-provider.ts
@@ -60,10 +60,11 @@ export default class TemplateCompletionProvider {
       PLACEHOLDER + ')))}}'
     ];
 
+    let validText = '';
     while (cases.length) {
       normalPlaceholder = cases.shift();
       try {
-        let validText = this.getTextForGuessing(originalText, offset, normalPlaceholder);
+        validText = this.getTextForGuessing(originalText, offset, normalPlaceholder);
         ast = preprocess(validText);
         log('validText', validText);
         break;
@@ -77,7 +78,7 @@ export default class TemplateCompletionProvider {
       return [];
     }
 
-    const focusPath = ASTPath.toPosition(ast, toPosition(params.position));
+    const focusPath = ASTPath.toPosition(ast, toPosition(params.position), validText);
 
     if (!focusPath) {
       return [];

--- a/src/definition-providers/entry.ts
+++ b/src/definition-providers/entry.ts
@@ -1,9 +1,9 @@
 import { RequestHandler, TextDocumentPositionParams, Definition } from 'vscode-languageserver';
-
 import Server from './../server';
 import { getExtension } from './../utils/file-extension';
 import TemplateDefinitionProvider from './template';
 import ScriptDefinitionProvider from './script';
+import { logError } from '../utils/logger';
 
 export default class DefinitionProvider {
   public template!: TemplateDefinitionProvider;
@@ -23,13 +23,18 @@ export default class DefinitionProvider {
       return null;
     }
 
-    let extension = getExtension(params.textDocument);
+    try {
+      let extension = getExtension(params.textDocument);
 
-    if (extension === '.hbs') {
-      return await this.template.handle(params, project);
-    } else if (extension === '.js' || extension === '.ts') {
-      return await this.script.handle(params, project);
-    } else {
+      if (extension === '.hbs') {
+        return await this.template.handle(params, project);
+      } else if (extension === '.js' || extension === '.ts') {
+        return await this.script.handle(params, project);
+      } else {
+        return null;
+      }
+    } catch (e) {
+      logError(e);
       return null;
     }
   }

--- a/src/definition-providers/script.ts
+++ b/src/definition-providers/script.ts
@@ -21,7 +21,7 @@ export default class ScriptDefinitionProvider {
       sourceType: 'module'
     });
 
-    const astPath = ASTPath.toPosition(ast, toPosition(params.position));
+    const astPath = ASTPath.toPosition(ast, toPosition(params.position), content);
 
     if (!astPath) {
       return null;

--- a/src/definition-providers/template.ts
+++ b/src/definition-providers/template.ts
@@ -21,7 +21,7 @@ export default class TemplateDefinitionProvider {
     const isScript = ['.ts', '.js'].includes(ext as string);
     let content = isScript ? searchAndExtractHbs(document.getText()) : document.getText();
     let ast = preprocess(content);
-    let focusPath = ASTPath.toPosition(ast, toPosition(params.position));
+    let focusPath = ASTPath.toPosition(ast, toPosition(params.position), content);
     if (!focusPath) {
       return null;
     }

--- a/src/glimmer-utils.ts
+++ b/src/glimmer-utils.ts
@@ -4,7 +4,7 @@ import { containsPosition } from './estree-utils';
 type ScopeValue = [string, ASTPath, number];
 
 export function componentNameForPath(astPath: ASTPath) {
-  if (isLocalPathExpression(astPath)) {
+  if (isLocalScopedPathExpression(astPath)) {
     const scope = getLocalScope(astPath);
     const pathName = getLocalPathName(astPath.node);
     if (pathName) {
@@ -30,7 +30,7 @@ function getLocalPathName(node: any) {
   return pathName;
 }
 
-export function isLocalPathExpression(astPath: ASTPath) {
+export function isLocalScopedPathExpression(astPath: ASTPath) {
   const pathName = getLocalPathName(astPath.node);
   if (!pathName) {
     return false;

--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -320,6 +320,9 @@ function isCallExpression(node: any): boolean {
 export function isLocalPathExpression(path: any): boolean {
   return isPathExpression(path.node) && path.node.this === true;
 }
+export function isScopedPathExpression(path: any): boolean {
+  return isPathExpression(path.node) && path.node.this === false && path.node.data === false;
+}
 export function isComponentArgumentName(path: any): boolean {
   return hasNodeType(path.node, 'AttrNode') && path.node.name.startsWith('@');
 }

--- a/test/__snapshots__/glimmer-utils-test.ts.snap
+++ b/test/__snapshots__/glimmer-utils-test.ts.snap
@@ -25,6 +25,7 @@ Object {
 
 exports[`glimmer-utils maybeBlockParamDefinition able to handle single fiew params 1`] = `
 Object {
+  "getParentPath": [Function],
   "index": 1,
   "name": "boo",
   "type": "BlockParam",
@@ -33,6 +34,7 @@ Object {
 
 exports[`glimmer-utils maybeBlockParamDefinition able to handle single param 1`] = `
 Object {
+  "getParentPath": [Function],
   "index": 0,
   "name": "items",
   "type": "BlockParam",

--- a/test/__snapshots__/glimmer-utils-test.ts.snap
+++ b/test/__snapshots__/glimmer-utils-test.ts.snap
@@ -24,19 +24,517 @@ Object {
 `;
 
 exports[`glimmer-utils maybeBlockParamDefinition able to handle single fiew params 1`] = `
-Object {
-  "getParentPath": [Function],
-  "index": 1,
+BlockParamDefinition {
   "name": "boo",
+  "path": ASTPath {
+    "content": "",
+    "index": 1,
+    "path": Array [
+      Object {
+        "blockParams": Array [],
+        "body": Array [
+          Object {
+            "attributes": Array [],
+            "blockParams": Array [
+              "items",
+              "boo",
+              "zoo",
+            ],
+            "children": Array [
+              Object {
+                "chars": "
+",
+                "loc": Object {
+                  "end": Object {
+                    "column": 0,
+                    "line": 2,
+                  },
+                  "source": null,
+                  "start": Object {
+                    "column": 30,
+                    "line": 1,
+                  },
+                },
+                "type": "TextNode",
+              },
+              Object {
+                "escaped": true,
+                "hash": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 0,
+                      "line": 1,
+                    },
+                    "source": "(synthetic)",
+                    "start": Object {
+                      "column": 0,
+                      "line": 1,
+                    },
+                  },
+                  "pairs": Array [],
+                  "type": "Hash",
+                },
+                "loc": Object {
+                  "end": Object {
+                    "column": 7,
+                    "line": 2,
+                  },
+                  "source": null,
+                  "start": Object {
+                    "column": 0,
+                    "line": 2,
+                  },
+                },
+                "params": Array [],
+                "path": Object {
+                  "data": false,
+                  "loc": SourceLocation {
+                    "end": Object {
+                      "column": 5,
+                      "line": 2,
+                    },
+                    "source": undefined,
+                    "start": Object {
+                      "column": 2,
+                      "line": 2,
+                    },
+                  },
+                  "original": "foo",
+                  "parts": Array [
+                    "foo",
+                  ],
+                  "this": false,
+                  "type": "PathExpression",
+                },
+                "strip": Object {
+                  "close": false,
+                  "open": false,
+                },
+                "type": "MustacheStatement",
+              },
+              Object {
+                "chars": "
+",
+                "loc": Object {
+                  "end": Object {
+                    "column": 0,
+                    "line": 3,
+                  },
+                  "source": null,
+                  "start": Object {
+                    "column": 7,
+                    "line": 2,
+                  },
+                },
+                "type": "TextNode",
+              },
+            ],
+            "comments": Array [],
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 3,
+              },
+              "source": null,
+              "start": Object {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "modifiers": Array [],
+            "selfClosing": false,
+            "tag": "Component",
+            "type": "ElementNode",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 3,
+          },
+          "source": null,
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "type": "Template",
+      },
+      Object {
+        "attributes": Array [],
+        "blockParams": Array [
+          "items",
+          "boo",
+          "zoo",
+        ],
+        "children": Array [
+          Object {
+            "chars": "
+",
+            "loc": Object {
+              "end": Object {
+                "column": 0,
+                "line": 2,
+              },
+              "source": null,
+              "start": Object {
+                "column": 30,
+                "line": 1,
+              },
+            },
+            "type": "TextNode",
+          },
+          Object {
+            "escaped": true,
+            "hash": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 0,
+                  "line": 1,
+                },
+                "source": "(synthetic)",
+                "start": Object {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "pairs": Array [],
+              "type": "Hash",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 2,
+              },
+              "source": null,
+              "start": Object {
+                "column": 0,
+                "line": 2,
+              },
+            },
+            "params": Array [],
+            "path": Object {
+              "data": false,
+              "loc": SourceLocation {
+                "end": Object {
+                  "column": 5,
+                  "line": 2,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 2,
+                  "line": 2,
+                },
+              },
+              "original": "foo",
+              "parts": Array [
+                "foo",
+              ],
+              "this": false,
+              "type": "PathExpression",
+            },
+            "strip": Object {
+              "close": false,
+              "open": false,
+            },
+            "type": "MustacheStatement",
+          },
+          Object {
+            "chars": "
+",
+            "loc": Object {
+              "end": Object {
+                "column": 0,
+                "line": 3,
+              },
+              "source": null,
+              "start": Object {
+                "column": 7,
+                "line": 2,
+              },
+            },
+            "type": "TextNode",
+          },
+        ],
+        "comments": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 3,
+          },
+          "source": null,
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "modifiers": Array [],
+        "selfClosing": false,
+        "tag": "Component",
+        "type": "ElementNode",
+      },
+    ],
+    "position": Object {
+      "column": 22,
+      "line": 1,
+    },
+  },
   "type": "BlockParam",
 }
 `;
 
 exports[`glimmer-utils maybeBlockParamDefinition able to handle single param 1`] = `
-Object {
-  "getParentPath": [Function],
-  "index": 0,
+BlockParamDefinition {
   "name": "items",
+  "path": ASTPath {
+    "content": "",
+    "index": 1,
+    "path": Array [
+      Object {
+        "blockParams": Array [],
+        "body": Array [
+          Object {
+            "attributes": Array [],
+            "blockParams": Array [
+              "items",
+            ],
+            "children": Array [
+              Object {
+                "chars": "
+",
+                "loc": Object {
+                  "end": Object {
+                    "column": 0,
+                    "line": 2,
+                  },
+                  "source": null,
+                  "start": Object {
+                    "column": 22,
+                    "line": 1,
+                  },
+                },
+                "type": "TextNode",
+              },
+              Object {
+                "escaped": true,
+                "hash": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 0,
+                      "line": 1,
+                    },
+                    "source": "(synthetic)",
+                    "start": Object {
+                      "column": 0,
+                      "line": 1,
+                    },
+                  },
+                  "pairs": Array [],
+                  "type": "Hash",
+                },
+                "loc": Object {
+                  "end": Object {
+                    "column": 7,
+                    "line": 2,
+                  },
+                  "source": null,
+                  "start": Object {
+                    "column": 0,
+                    "line": 2,
+                  },
+                },
+                "params": Array [],
+                "path": Object {
+                  "data": false,
+                  "loc": SourceLocation {
+                    "end": Object {
+                      "column": 5,
+                      "line": 2,
+                    },
+                    "source": undefined,
+                    "start": Object {
+                      "column": 2,
+                      "line": 2,
+                    },
+                  },
+                  "original": "foo",
+                  "parts": Array [
+                    "foo",
+                  ],
+                  "this": false,
+                  "type": "PathExpression",
+                },
+                "strip": Object {
+                  "close": false,
+                  "open": false,
+                },
+                "type": "MustacheStatement",
+              },
+              Object {
+                "chars": "
+",
+                "loc": Object {
+                  "end": Object {
+                    "column": 0,
+                    "line": 3,
+                  },
+                  "source": null,
+                  "start": Object {
+                    "column": 7,
+                    "line": 2,
+                  },
+                },
+                "type": "TextNode",
+              },
+            ],
+            "comments": Array [],
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 3,
+              },
+              "source": null,
+              "start": Object {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "modifiers": Array [],
+            "selfClosing": false,
+            "tag": "Component",
+            "type": "ElementNode",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 3,
+          },
+          "source": null,
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "type": "Template",
+      },
+      Object {
+        "attributes": Array [],
+        "blockParams": Array [
+          "items",
+        ],
+        "children": Array [
+          Object {
+            "chars": "
+",
+            "loc": Object {
+              "end": Object {
+                "column": 0,
+                "line": 2,
+              },
+              "source": null,
+              "start": Object {
+                "column": 22,
+                "line": 1,
+              },
+            },
+            "type": "TextNode",
+          },
+          Object {
+            "escaped": true,
+            "hash": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 0,
+                  "line": 1,
+                },
+                "source": "(synthetic)",
+                "start": Object {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "pairs": Array [],
+              "type": "Hash",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 2,
+              },
+              "source": null,
+              "start": Object {
+                "column": 0,
+                "line": 2,
+              },
+            },
+            "params": Array [],
+            "path": Object {
+              "data": false,
+              "loc": SourceLocation {
+                "end": Object {
+                  "column": 5,
+                  "line": 2,
+                },
+                "source": undefined,
+                "start": Object {
+                  "column": 2,
+                  "line": 2,
+                },
+              },
+              "original": "foo",
+              "parts": Array [
+                "foo",
+              ],
+              "this": false,
+              "type": "PathExpression",
+            },
+            "strip": Object {
+              "close": false,
+              "open": false,
+            },
+            "type": "MustacheStatement",
+          },
+          Object {
+            "chars": "
+",
+            "loc": Object {
+              "end": Object {
+                "column": 0,
+                "line": 3,
+              },
+              "source": null,
+              "start": Object {
+                "column": 7,
+                "line": 2,
+              },
+            },
+            "type": "TextNode",
+          },
+        ],
+        "comments": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 3,
+          },
+          "source": null,
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "modifiers": Array [],
+        "selfClosing": false,
+        "tag": "Component",
+        "type": "ElementNode",
+      },
+    ],
+    "position": Object {
+      "column": 16,
+      "line": 1,
+    },
+  },
   "type": "BlockParam",
 }
 `;

--- a/test/__snapshots__/glimmer-utils-test.ts.snap
+++ b/test/__snapshots__/glimmer-utils-test.ts.snap
@@ -22,3 +22,19 @@ Object {
   "type": "PathExpression",
 }
 `;
+
+exports[`glimmer-utils maybeBlockParamDefinition able to handle single fiew params 1`] = `
+Object {
+  "index": 1,
+  "name": "boo",
+  "type": "BlockParam",
+}
+`;
+
+exports[`glimmer-utils maybeBlockParamDefinition able to handle single param 1`] = `
+Object {
+  "index": 0,
+  "name": "items",
+  "type": "BlockParam",
+}
+`;

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -309,6 +309,65 @@ Array [
 ]
 `;
 
+exports[`integration Able to provide autocomplete information for local scoped params support component name autocomplete from block params 1`] = `
+Array [
+  Object {
+    "detail": "component",
+    "kind": 7,
+    "label": "Foo",
+    "textEdit": Object {
+      "newText": "Foo",
+      "range": Object {
+        "end": Object {
+          "character": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 1,
+          "line": 2,
+        },
+      },
+    },
+  },
+  Object {
+    "detail": "Param from <MyComponent as |...|>",
+    "kind": 6,
+    "label": "boo",
+    "textEdit": Object {
+      "newText": "boo",
+      "range": Object {
+        "end": Object {
+          "character": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 1,
+          "line": 2,
+        },
+      },
+    },
+  },
+  Object {
+    "detail": "Param from {{#my-component as |...|}}",
+    "kind": 6,
+    "label": "bar",
+    "textEdit": Object {
+      "newText": "bar",
+      "range": Object {
+        "end": Object {
+          "character": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 1,
+          "line": 2,
+        },
+      },
+    },
+  },
+]
+`;
+
 exports[`integration Able to provide autocomplete information for local scoped params support mustache blocks 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -309,6 +309,138 @@ Array [
 ]
 `;
 
+exports[`integration Able to provide autocomplete information for local scoped params support mustache blocks 1`] = `
+Array [
+  Object {
+    "detail": "Param from {{#my-component as |...|}}",
+    "kind": 6,
+    "label": "bar",
+    "textEdit": Object {
+      "newText": "bar",
+      "range": Object {
+        "end": Object {
+          "character": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 1,
+        },
+      },
+    },
+  },
+  Object {
+    "detail": "Ember",
+    "kind": 3,
+    "label": "unbound",
+    "textEdit": Object {
+      "newText": "unbound",
+      "range": Object {
+        "end": Object {
+          "character": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 1,
+        },
+      },
+    },
+    "usableIn": Array [
+      "MustachePath",
+      "SubExpressionPath",
+    ],
+  },
+  Object {
+    "detail": "Ember",
+    "kind": 3,
+    "label": "debugger",
+    "textEdit": Object {
+      "newText": "debugger",
+      "range": Object {
+        "end": Object {
+          "character": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 1,
+        },
+      },
+    },
+    "usableIn": Array [
+      "MustachePath",
+    ],
+  },
+]
+`;
+
+exports[`integration Able to provide autocomplete information for local scoped params support tag blocks 1`] = `
+Array [
+  Object {
+    "detail": "Param from <MyComponent as |...|>",
+    "kind": 6,
+    "label": "bar",
+    "textEdit": Object {
+      "newText": "bar",
+      "range": Object {
+        "end": Object {
+          "character": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 1,
+        },
+      },
+    },
+  },
+  Object {
+    "detail": "Ember",
+    "kind": 3,
+    "label": "unbound",
+    "textEdit": Object {
+      "newText": "unbound",
+      "range": Object {
+        "end": Object {
+          "character": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 1,
+        },
+      },
+    },
+    "usableIn": Array [
+      "MustachePath",
+      "SubExpressionPath",
+    ],
+  },
+  Object {
+    "detail": "Ember",
+    "kind": 3,
+    "label": "debugger",
+    "textEdit": Object {
+      "newText": "debugger",
+      "range": Object {
+        "end": Object {
+          "character": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 1,
+        },
+      },
+    },
+    "usableIn": Array [
+      "MustachePath",
+    ],
+  },
+]
+`;
+
 exports[`integration Autocomplete works for broken templates autocomplete information for component #1 {{ 1`] = `
 Array [
   Object {

--- a/test/glimmer-utils-test.ts
+++ b/test/glimmer-utils-test.ts
@@ -1,7 +1,7 @@
 import { Position } from 'vscode-languageserver';
 import { preprocess } from '@glimmer/syntax';
 
-import ASTPath, { getLocalScope, componentNameForPath, sourceForNode, focusedBlockParamName, maybeBlockParamDefinition } from '../src/glimmer-utils';
+import ASTPath, { getLocalScope, maybeComponentNameForPath, sourceForNode, focusedBlockParamName, maybeBlockParamDefinition } from '../src/glimmer-utils';
 import { toPosition } from '../src/estree-utils';
 
 describe('glimmer-utils', function() {
@@ -31,7 +31,7 @@ describe('glimmer-utils', function() {
       expect(getLocalScope(astPath).map(([el, , ind]) => [el, ind])).toEqual([['item', 0], ['bar', 1], ['items', 0]]);
     });
   });
-  describe('componentNameForPath', function() {
+  describe('maybeComponentNameForPath', function() {
     it('works as expected', function() {
       const input = `
 <Component as |items|>
@@ -41,7 +41,7 @@ describe('glimmer-utils', function() {
 </Component>
         `;
       const astPath = ASTPath.toPosition(preprocess(input), toPosition(Position.create(3, 5)));
-      expect(componentNameForPath(astPath)).toEqual('Component');
+      expect(maybeComponentNameForPath(astPath)).toEqual('Component');
     });
   });
   describe('sourceForNode', function() {

--- a/test/glimmer-utils-test.ts
+++ b/test/glimmer-utils-test.ts
@@ -28,7 +28,7 @@ describe('glimmer-utils', function() {
 </Component>
         `;
       const astPath = ASTPath.toPosition(preprocess(input), toPosition(Position.create(3, 5)));
-      expect(getLocalScope(astPath).map(([el, , ind]) => [el, ind])).toEqual([['item', 0], ['bar', 1], ['items', 0]]);
+      expect(getLocalScope(astPath).map(({ name, index }) => [name, index])).toEqual([['item', 0], ['bar', 1], ['items', 0]]);
     });
   });
   describe('maybeComponentNameForPath', function() {

--- a/test/glimmer-utils-test.ts
+++ b/test/glimmer-utils-test.ts
@@ -1,7 +1,7 @@
 import { Position } from 'vscode-languageserver';
 import { preprocess } from '@glimmer/syntax';
 
-import ASTPath, { getLocalScope, componentNameForPath } from '../src/glimmer-utils';
+import ASTPath, { getLocalScope, componentNameForPath, sourceForNode } from '../src/glimmer-utils';
 import { toPosition } from '../src/estree-utils';
 
 describe('glimmer-utils', function() {
@@ -42,6 +42,26 @@ describe('glimmer-utils', function() {
         `;
       const astPath = ASTPath.toPosition(preprocess(input), toPosition(Position.create(3, 5)));
       expect(componentNameForPath(astPath)).toEqual('Component');
+    });
+  });
+  describe('sourceForNode', function() {
+    it('works as expected', function() {
+      const input = `
+      <Component as |items|>
+      {{#let items as |item bar|}}
+      {{items}}
+      {{/let}}
+      </Component>
+              `;
+      const astPath = ASTPath.toPosition(preprocess(input), toPosition(Position.create(2, 2)));
+      expect(astPath.node.tag).toEqual('Component');
+      expect(sourceForNode(astPath.node, input)).toEqual(input.trim());
+    });
+    it('works as expected for MustachePaths', function() {
+      const input = ['<Component as |items|>', '{{#let items as |item bar|}}', '{{items}}', '{{/let}}', '</Component>'].join('\n');
+      const astPath = ASTPath.toPosition(preprocess(input), toPosition(Position.create(2, 3)));
+      expect(astPath.node.original).toEqual('items');
+      expect(sourceForNode(astPath.node, input)).toEqual('items');
     });
   });
 });

--- a/test/glimmer-utils-test.ts
+++ b/test/glimmer-utils-test.ts
@@ -1,7 +1,7 @@
 import { Position } from 'vscode-languageserver';
 import { preprocess } from '@glimmer/syntax';
 
-import ASTPath, { getLocalScope, componentNameForPath, sourceForNode } from '../src/glimmer-utils';
+import ASTPath, { getLocalScope, componentNameForPath, sourceForNode, focusedBlockParamName, maybeBlockParamDefinition } from '../src/glimmer-utils';
 import { toPosition } from '../src/estree-utils';
 
 describe('glimmer-utils', function() {
@@ -62,6 +62,82 @@ describe('glimmer-utils', function() {
       const astPath = ASTPath.toPosition(preprocess(input), toPosition(Position.create(2, 3)));
       expect(astPath.node.original).toEqual('items');
       expect(sourceForNode(astPath.node, input)).toEqual('items');
+    });
+  });
+  describe('maybeBlockParamDefinition', function() {
+    it('able to handle wrong paths', function() {
+      const input = ['<Component as |items|>', '{{foo}}', '</Component>'].join('\n');
+      const pos = toPosition(Position.create(1, 3));
+      const astPath = ASTPath.toPosition(preprocess(input), pos);
+      expect(maybeBlockParamDefinition(astPath, input, pos)).toEqual(undefined);
+    });
+    it('able to handle single param', function() {
+      const input = ['<Component as |items|>', '{{foo}}', '</Component>'].join('\n');
+      const pos = toPosition(Position.create(0, 16));
+      const astPath = ASTPath.toPosition(preprocess(input), pos);
+      expect(maybeBlockParamDefinition(astPath, input, pos)).toMatchSnapshot();
+    });
+    it('able to handle single fiew params', function() {
+      const input = ['<Component as |items boo zoo|>', '{{foo}}', '</Component>'].join('\n');
+      const pos = toPosition(Position.create(0, 22));
+      const astPath = ASTPath.toPosition(preprocess(input), pos);
+      expect(maybeBlockParamDefinition(astPath, input, pos)).toMatchSnapshot();
+    });
+  });
+  describe('focusedBlockParamName', function() {
+    it('works as expected for MustachePaths', function() {
+      const input = ['<Component as |items|>', '{{#let items as |item bar|}}', '{{items}}', '{{/let}}', '</Component>'].join('\n');
+      let paramName = focusedBlockParamName(input, toPosition(Position.create(1, 24)));
+      expect(paramName).toEqual('bar');
+    });
+    it('works as expected for corner cases [left]', function() {
+      const input = ['<C as |items|>'].join('\n');
+      let paramName = focusedBlockParamName(input, toPosition(Position.create(0, 7)));
+      expect(paramName).toEqual('items');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 8)));
+      expect(paramName).toEqual('items');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 6)));
+      expect(paramName).toEqual('');
+    });
+    it('works as expected for corner cases [right]', function() {
+      const input = ['<C as |items|>'].join('\n');
+      let paramName = focusedBlockParamName(input, toPosition(Position.create(0, 12)));
+      expect(paramName).toEqual('items');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 11)));
+      expect(paramName).toEqual('items');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 13)));
+      expect(paramName).toEqual('');
+    });
+    it('works as expected for corner cases for 1+ param [right]', function() {
+      const input = ['<C as |items foo|>'].join('\n');
+      let paramName = focusedBlockParamName(input, toPosition(Position.create(0, 6)));
+      expect(paramName).toEqual('');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 12)));
+      expect(paramName).toEqual('items');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 13)));
+      expect(paramName).toEqual('foo');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 16)));
+      expect(paramName).toEqual('foo');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 17)));
+      expect(paramName).toEqual('');
+    });
+    it('works as expected for corner cases for 1+ param and long blanks', function() {
+      const input = ['<C as | items  foo |>'].join('\n');
+      let paramName = focusedBlockParamName(input, toPosition(Position.create(0, 7)));
+      expect(paramName).toEqual('');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 13)));
+      expect(paramName).toEqual('items');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 14)));
+      expect(paramName).toEqual('');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 15)));
+      expect(paramName).toEqual('foo');
+      paramName = focusedBlockParamName(input, toPosition(Position.create(0, 19)));
+      expect(paramName).toEqual('');
+    });
+    it('works as expected for Tags', function() {
+      const input = ['<Component as |items|>', '{{#let items as |item bar|}}', '{{items}}', '{{/let}}', '</Component>'].join('\n');
+      let paramName = focusedBlockParamName(input, toPosition(Position.create(0, 16)));
+      expect(paramName).toEqual('items');
     });
   });
 });

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -611,6 +611,41 @@ describe('integration', function() {
     });
   });
 
+  describe('Able to provide autocomplete information for local scoped params', () => {
+    it('support tag blocks', async () => {
+      const result = await getResult(
+        CompletionRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'foo.hbs': ['<MyComponent as |bar|>', '{{b}}', '</MyComponent>'].join('\n')
+            }
+          }
+        },
+        'app/components/foo.hbs',
+        { line: 1, character: 3 }
+      );
+      expect(result).toMatchSnapshot();
+    });
+    it('support mustache blocks', async () => {
+      const result = await getResult(
+        CompletionRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'foo.hbs': ['{{#my-component as |bar|}}', '{{b}}', '{{/my-component}}'].join('\n')
+            }
+          }
+        },
+        'app/components/foo.hbs',
+        { line: 1, character: 3 }
+      );
+      expect(result).toMatchSnapshot();
+    });
+  });
+
   describe('Able to load API from project itself', () => {
     it('project custom completion:template', async () => {
       const result = await getResult(

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -644,6 +644,22 @@ describe('integration', function() {
       );
       expect(result).toMatchSnapshot();
     });
+    it('support component name autocomplete from block params', async () => {
+      const result = await getResult(
+        CompletionRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'foo.hbs': ['{{#my-component as |bar|}}', '<MyComponent as |boo|>', '<b />', '</MyComponent>', '{{/my-component}}'].join('\n')
+            }
+          }
+        },
+        'app/components/foo.hbs',
+        { line: 2, character: 1 }
+      );
+      expect(result).toMatchSnapshot();
+    });
   });
 
   describe('Able to load API from project itself', () => {


### PR DESCRIPTION
this pr allow us:

* get node source code (for Handlebars)
* check `PathExpression` for scoped definition (via blocks)
* capture focus on block param definition
* get block param declaration node (from `PathExpression`)

new public API for `focusPath`:

```ts
type BlockParam = {
        type: 'BlockParam';
        name: string;
        path: ASTPath;
        index: number
};

{
  sourceForNode: () => string | undefined,
  sourceForParent: () => string | undefined,
  metaForType(string: 'handlebars') {
    return {
      maybeBlockParamDefinition: undefined | BlockParam,
      maybeBlockParamDeclarationBlockPath: undefined | ASTPath,
      localScope: BlockParam[]
    }
  }
}
```

https://github.com/lifeart/ember-language-server/issues/12