### PR TITLE
allow block params autocomplete

### DIFF
--- a/src/completion-provider/template-completion-provider.ts
+++ b/src/completion-provider/template-completion-provider.ts
@@ -49,6 +49,8 @@ export default class TemplateCompletionProvider {
       PLACEHOLDER,
       PLACEHOLDER + '"',
       PLACEHOLDER + "'",
+      // block params autocomplete
+      PLACEHOLDER + '| />',
       PLACEHOLDER + '}} />',
       PLACEHOLDER + '"}}',
       PLACEHOLDER + '}}',


### PR DESCRIPTION
improved block autocomplete case for 
`<Some Component as |...` case