### PR TITLE
bugfix: go-to definition tests jumping

### DIFF
--- a/src/builtin-addons/core/template-definition-provider.ts
+++ b/src/builtin-addons/core/template-definition-provider.ts
@@ -7,7 +7,7 @@ import { isLinkToTarget, isLinkComponentRouteTarget } from './../../utils/ast-he
 import ASTPath from './../../glimmer-utils';
 import { getGlobalRegistry } from './../../utils/registry-api';
 import { normalizeToClassicComponent } from '../../utils/normalizers';
-import { isTemplatePath, getComponentNameFromURI, isModuleUnificationApp, getPodModulePrefix } from './../../utils/layout-helpers';
+import { isTemplatePath, isTestFile, getComponentNameFromURI, isModuleUnificationApp, getPodModulePrefix } from './../../utils/layout-helpers';
 
 import {
   getAbstractHelpersParts,
@@ -26,7 +26,7 @@ export function getPathsFromRegistry(type: 'helper' | 'modifier' | 'component', 
   const absRoot = path.normalize(root);
   const registry = getGlobalRegistry();
   const bucket: any = registry[type].get(name) || new Set();
-  return Array.from(bucket).filter((el: string) => path.normalize(el).includes(absRoot) && fs.existsSync(el)) as string[];
+  return Array.from(bucket).filter((el: string) => path.normalize(el).includes(absRoot) && !isTestFile(path.normalize(el)) && fs.existsSync(el)) as string[];
 }
 
 export function provideComponentTemplatePaths(root: string, rawComponentName: string) {

--- a/src/builtin-addons/core/template-definition-provider.ts
+++ b/src/builtin-addons/core/template-definition-provider.ts
@@ -26,6 +26,7 @@ export function getPathsFromRegistry(type: 'helper' | 'modifier' | 'component', 
   const absRoot = path.normalize(root);
   const registry = getGlobalRegistry();
   const bucket: any = registry[type].get(name) || new Set();
+
   return Array.from(bucket).filter((el: string) => path.normalize(el).includes(absRoot) && !isTestFile(path.normalize(el)) && fs.existsSync(el)) as string[];
 }
 

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -274,6 +274,18 @@ export function isTemplatePath(filePath: string) {
   return filePath.endsWith('.hbs');
 }
 
+export function normalizedPath(filePath: string) {
+  if (filePath.includes('\\')) {
+    return filePath.split('\\').join('/');
+  } else {
+    return filePath;
+  }
+}
+
+export function isTestFile(filePath: string) {
+  return normalizedPath(filePath).includes('/tests/');
+}
+
 export function hasAddonFolderInPath(name: string) {
   return name.includes(path.sep + 'addon' + path.sep);
 }

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -2962,6 +2962,68 @@ Object {
 }
 `;
 
+exports[`integration Go to definition works for all supported cases go to definition from handlebars template working if we have test for component 1`] = `
+Object {
+  "registry": Object {
+    "component": Object {
+      "darling": Array [
+        "app/components/darling.ts",
+        "tests/integration/components/darling/component-test.js",
+      ],
+      "hello": Array [
+        "app/components/hello.hbs",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/app/components/darling.ts",
+    },
+  ],
+}
+`;
+
+exports[`integration Go to definition works for all supported cases go to definition from script template working if we have test for component 1`] = `
+Object {
+  "registry": Object {
+    "component": Object {
+      "darling": Array [
+        "app/components/darling.ts",
+        "tests/integration/components/darling/component-test.js",
+      ],
+      "hello": Array [
+        "app/components/hello.ts",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/app/components/darling.ts",
+    },
+  ],
+}
+`;
+
 exports[`integration Go to definition works for all supported cases go to local template-only component 1`] = `
 Object {
   "registry": Object {

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -508,6 +508,34 @@ describe('integration', function() {
 
       expect(result).toMatchSnapshot();
     });
+
+    it('go to definition working if we have test for component', async () => {
+      const result = await getResult(
+        DefinitionRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.ts': 'hbs`<Darling />`',
+              'darling.ts': ''
+            }
+          },
+          tests: {
+            integration: {
+              components: {
+                darling: {
+                  'component-test.js': ''
+                }
+              }
+            }
+          }
+        },
+        'app/components/hello.ts',
+        { line: 0, character: 6 }
+      );
+
+      expect(result).toMatchSnapshot();
+    });
   });
 
   describe('GlimmerX', () => {

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -535,7 +535,7 @@ describe('integration', function () {
       expect(result).toMatchSnapshot();
     });
 
-    it('go to definition working if we have test for component', async () => {
+    it('go to definition from script template working if we have test for component', async () => {
       const result = await getResult(
         DefinitionRequest.type,
         connection,
@@ -543,21 +543,48 @@ describe('integration', function () {
           app: {
             components: {
               'hello.ts': 'hbs`<Darling />`',
-              'darling.ts': ''
-            }
+              'darling.ts': '',
+            },
           },
           tests: {
             integration: {
               components: {
                 darling: {
-                  'component-test.js': ''
-                }
-              }
-            }
-          }
+                  'component-test.js': '',
+                },
+              },
+            },
+          },
         },
         'app/components/hello.ts',
         { line: 0, character: 6 }
+      );
+
+      expect(result).toMatchSnapshot();
+    });
+    it('go to definition from handlebars template working if we have test for component', async () => {
+      const result = await getResult(
+        DefinitionRequest.type,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.hbs': '<Darling />',
+              'darling.ts': '',
+            },
+          },
+          tests: {
+            integration: {
+              components: {
+                darling: {
+                  'component-test.js': '',
+                },
+              },
+            },
+          },
+        },
+        'app/components/hello.hbs',
+        { line: 0, character: 4 }
       );
 
       expect(result).toMatchSnapshot();


### PR DESCRIPTION
This PR should fix go-to definition behavour, mentioned in #105 

Can't create failing test :(

