### PR TITLE
chore: attempt to use absolute paths

### DIFF
--- a/src/project-roots.ts
+++ b/src/project-roots.ts
@@ -5,7 +5,14 @@ import { uriToFilePath } from 'vscode-languageserver/lib/files';
 import { logError, logInfo } from './utils/logger';
 import * as walkSync from 'walk-sync';
 import * as fs from 'fs';
-import { isGlimmerNativeProject, isGlimmerXProject, getPodModulePrefix, findTestsForProject, isELSAddonRoot } from './utils/layout-helpers';
+import {
+  isGlimmerNativeProject,
+  isGlimmerXProject,
+  getPodModulePrefix,
+  findTestsForProject,
+  findAppItemsForProject,
+  isELSAddonRoot
+} from './utils/layout-helpers';
 import { addToRegistry, removeFromRegistry, normalizeMatchNaming, NormalizedRegistryItem } from './utils/registry-api';
 import { ProjectProviders, collectProjectProviders, initBuiltinProviders } from './utils/addon-api';
 import Server from './server';
@@ -114,6 +121,7 @@ export class Project {
       }
     });
     findTestsForProject(this);
+    findAppItemsForProject(this);
     this.providers.initFunctions.forEach((initFn) => {
       try {
         let initResult = initFn(server, this);
@@ -215,7 +223,8 @@ export default class ProjectRoots {
       project.init(this.server);
       return {
         initIssues: project.initIssues,
-        providers: project.providers
+        providers: project.providers,
+        registry: this.server.getRegistry(project.root)
       };
     } catch (e) {
       logError(e);

--- a/src/utils/definition-helpers.ts
+++ b/src/utils/definition-helpers.ts
@@ -17,7 +17,7 @@ const mProjectInRepoAddonsRoots = memoize(getProjectInRepoAddonsRoots, {
 
 export function pathsToLocations(...paths: string[]): Location[] {
   return paths.filter(fs.existsSync).map((modulePath) => {
-    return Location.create(URI.file(modulePath).toString(), Range.create(0, 0, 0, 0));
+    return Location.create(URI.file(modulePath.split(':').pop() as string).toString(), Range.create(0, 0, 0, 0));
   });
 }
 

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -352,7 +352,7 @@ export function listPodsComponents(root: string): CompletionItem[] {
   if (podModulePrefix === null) {
     return [];
   }
-  const entryPath = path.join(root, 'app', podModulePrefix, 'components');
+  const entryPath = path.resolve(path.join(root, 'app', podModulePrefix, 'components'));
   const jsPaths = safeWalkSync(entryPath, {
     directories: false,
     globs: ['**/*.{js,ts,hbs,css,less,scss}']
@@ -372,7 +372,7 @@ export function listPodsComponents(root: string): CompletionItem[] {
 }
 
 export function listMUComponents(root: string): CompletionItem[] {
-  const entryPath = path.join(root, 'src', 'ui', 'components');
+  const entryPath = path.resolve(path.join(root, 'src', 'ui', 'components'));
   const jsPaths = safeWalkSync(entryPath, {
     directories: false,
     globs: ['**/*.{js,ts,hbs}']
@@ -400,8 +400,9 @@ export function builtinModifiers(): CompletionItem[] {
   ];
 }
 
-export function listComponents(root: string): CompletionItem[] {
+export function listComponents(_root: string): CompletionItem[] {
   // log('listComponents');
+  const root = path.resolve(_root);
   const scriptEntry = path.join(root, 'app', 'components');
   const templateEntry = path.join(root, 'app', 'templates', 'components');
   const addonComponents = path.join(root, 'addon', 'components');
@@ -470,6 +471,23 @@ export function findTestsForProject(project: Project) {
   });
 }
 
+export function findAppItemsForProject(project: Project) {
+  const entry = path.resolve(path.join(project.root, 'app'));
+  const paths = safeWalkSync(entry, {
+    directories: false,
+    globs: ['**/*.{js,ts,css,less,sass,hbs}']
+  });
+
+  paths.forEach((filePath: string) => {
+    const fullPath = path.join(entry, filePath);
+    const item = project.matchPathToType(fullPath);
+    if (item) {
+      const normalizedItem = normalizeMatchNaming(item);
+      addToRegistry(normalizedItem.name, normalizedItem.type, [fullPath]);
+    }
+  });
+}
+
 function listCollection(
   root: string,
   prefix: 'app' | 'addon',
@@ -477,7 +495,7 @@ function listCollection(
   kindType: CompletionItemKind,
   detail: 'transform' | 'service' | 'model' | 'helper' | 'modifier'
 ) {
-  const entry = path.join(root, prefix, collectionName);
+  const entry = path.resolve(path.join(root, prefix, collectionName));
   const paths = safeWalkSync(entry, {
     directories: false,
     globs: ['**/*.{js,ts}']
@@ -515,8 +533,8 @@ export function listTransforms(root: string): CompletionItem[] {
   return listCollection(root, 'app', 'transforms', CompletionItemKind.Function, 'transform');
 }
 
-export function listRoutes(root: string): CompletionItem[] {
-  // log('listRoutes');
+export function listRoutes(_root: string): CompletionItem[] {
+  const root = path.resolve(_root);
   const scriptEntry = path.join(root, 'app', 'routes');
   const templateEntry = path.join(root, 'app', 'templates');
   const controllersEntry = path.join(root, 'app', 'controllers');


### PR DESCRIPTION
Need to be tested before merge.
May side on project roots discovery, definition links.

We need this change to allow deduplication for definition providing logic.
