### PR TITLE
Provides routes from the router definition file if exists

### DIFF
--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -394,11 +394,11 @@ function isBlock(node: any): boolean {
   return hasNodeType(node, 'BlockStatement');
 }
 
-function isString(node: any): boolean {
+export function isString(node: any): boolean {
   return hasNodeType(node, 'StringLiteral');
 }
 
-function isCallExpression(node: any): boolean {
+export function isCallExpression(node: any): boolean {
   return hasNodeType(node, 'CallExpression');
 }
 
@@ -408,6 +408,10 @@ export function isLocalPathExpression(path: any): boolean {
 
 export function isArgumentPathExpression(path: any): boolean {
   return isPathExpression(path.node) && path.node.data === true;
+}
+
+export function isObjectExpression(node: any): boolean {
+  return hasNodeType(node, 'ObjectExpression');
 }
 
 export function isScopedPathExpression(path: any): boolean {
@@ -424,6 +428,15 @@ export function isLinkComponentRouteTarget(path: any): boolean {
 
 export function isPathExpression(node: any): boolean {
   return hasNodeType(node, 'PathExpression');
+}
+
+export function isRouteDefinitionCall(node: any): boolean {
+  if (!hasNodeType(node, 'MemberExpression')) {
+    return false;
+  }
+  const calleeObject = node.object;
+  const calleeProperty = node.property;
+  return hasNodeType(calleeObject, 'ThisExpression') && hasNodeType(calleeProperty, 'Identifier') && calleeProperty.name == 'route';
 }
 
 function expressionHasIdentifierName(exp: any, name: string | string[]) {

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -2429,24 +2429,6 @@ Array [
   Object {
     "detail": "route",
     "kind": 17,
-    "label": "application",
-    "textEdit": Object {
-      "newText": "application",
-      "range": Object {
-        "end": Object {
-          "character": 12,
-          "line": 3,
-        },
-        "start": Object {
-          "character": 12,
-          "line": 3,
-        },
-      },
-    },
-  },
-  Object {
-    "detail": "route",
-    "kind": 17,
     "label": "definition",
     "textEdit": Object {
       "newText": "definition",
@@ -2468,6 +2450,24 @@ Array [
     "label": "test-route",
     "textEdit": Object {
       "newText": "test-route",
+      "range": Object {
+        "end": Object {
+          "character": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "character": 12,
+          "line": 3,
+        },
+      },
+    },
+  },
+  Object {
+    "detail": "route",
+    "kind": 17,
+    "label": "nested",
+    "textEdit": Object {
+      "newText": "nested",
       "range": Object {
         "end": Object {
           "character": 12,
@@ -2524,24 +2524,6 @@ Array [
   Object {
     "detail": "route",
     "kind": 17,
-    "label": "application",
-    "textEdit": Object {
-      "newText": "application",
-      "range": Object {
-        "end": Object {
-          "character": 23,
-          "line": 2,
-        },
-        "start": Object {
-          "character": 23,
-          "line": 2,
-        },
-      },
-    },
-  },
-  Object {
-    "detail": "route",
-    "kind": 17,
     "label": "definition",
     "textEdit": Object {
       "newText": "definition",
@@ -2563,6 +2545,24 @@ Array [
     "label": "test-route",
     "textEdit": Object {
       "newText": "test-route",
+      "range": Object {
+        "end": Object {
+          "character": 23,
+          "line": 2,
+        },
+        "start": Object {
+          "character": 23,
+          "line": 2,
+        },
+      },
+    },
+  },
+  Object {
+    "detail": "route",
+    "kind": 17,
+    "label": "nested",
+    "textEdit": Object {
+      "newText": "nested",
       "range": Object {
         "end": Object {
           "character": 23,

--- a/test/fixtures/mu-project/src/router.js
+++ b/test/fixtures/mu-project/src/router.js
@@ -7,11 +7,14 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
-  this.route('angle-completion');
-  this.route('definition');
-  this.route('test-route');
-  this.route('nested', function() {
+  this.route('test-route', function() {
     this.route('nested-route');
+  });
+  this.route('post', { path: '/post/:post_id' }, function() {
+    this.route('edit');
+    this.route('comments', { resetNamespace: true }, function() {
+      this.route('new');
+    });
   });
 });
 

--- a/test/fixtures/pod-project/app/router.js
+++ b/test/fixtures/pod-project/app/router.js
@@ -7,11 +7,14 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
-  this.route('angle-completion');
-  this.route('definition');
-  this.route('test-route');
-  this.route('nested', function() {
+  this.route('test-route', function() {
     this.route('nested-route');
+  });
+  this.route('post', { path: '/post/:post_id' }, function() {
+    this.route('edit');
+    this.route('comments', { resetNamespace: true }, function() {
+      this.route('new');
+    });
   });
 });
 

--- a/test/utils/layout-helpers-test.ts
+++ b/test/utils/layout-helpers-test.ts
@@ -104,17 +104,19 @@ describe('definition-helpers', function () {
   });
 
   describe('listRoutes()', function () {
+    const expectedRoutes = ['test-route', 'test-route.nested-route', 'post', 'post.edit', 'comments', 'comments.new'];
     it('return expected list of routes for classic project', function () {
-      const components = listRoutes(path.join(__dirname, './../fixtures/full-project'));
+      const routes = listRoutes(path.join(__dirname, './../fixtures/full-project'));
 
-      expect(components.map(({ label }: { label: string }) => label)).toEqual([
-        'angle-completion',
-        'application',
-        'definition',
-        'test-route',
-        'nested.nested-route',
-        'test-route',
-      ]);
+      expect(routes.map(({ label }: { label: string }) => label)).toEqual(['angle-completion', 'definition', 'test-route', 'nested', 'nested.nested-route']);
+    });
+    it('return expected list of routes for pod project', function () {
+      const routes = listRoutes(path.join(__dirname, './../fixtures/pod-project'));
+      expect(routes.map(({ label }: { label: string }) => label)).toEqual(expectedRoutes);
+    });
+    it('return expected list of routes for module unification project', function () {
+      const routes = listRoutes(path.join(__dirname, './../fixtures/mu-project'));
+      expect(routes.map(({ label }: { label: string }) => label)).toEqual(expectedRoutes);
     });
   });
 


### PR DESCRIPTION
We check for the `router.js` file and parse the routes from the file, obeying
`resetNamespace` option on the routes. Since the router.js is a single source
of information about the routes, this would cater to the following types of
projects: mu, pod, classic.

The only caveats are

1. Magic router defintions like , where adminRouter is routes from `ember-admin`

```
   Router.map(function() {
     adminRouter(this);
   });
```

since we list the routes from addons seperately, this should not be a problem.
But if the routes are 'mounted' on a sub route, then we'd loose the context.

2. Addons

We'd use the FS way here, as the `router.js` would not be present.
So no behavioural change from the previous implementation, but the routes could
be mounted on a sub route as in the previous case.

The only erroneous case will be when the `router.js` file itself has lot of
magic in it - in which case we don't list the routes from both sources. But I
think this situation would be too rare for us to worry about.