### PR TITLE
feat: add `bin` entry to `package.json`

### DIFF
--- a/bin/ember-language-server.js
+++ b/bin/ember-language-server.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/start-server');

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "engines": {
     "node": ">= 10.17.0"
   },
+  "bin": "bin/ember-language-server.js",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
Without a `bin` entry, Volta doesn't allow installing this package as a global package.

This `bin` entry, pointed to a JS file with the correct "hash-bang" and with the executable permission set, should allow for Volta to install this package.