### PR TITLE
Support long imports

### DIFF
--- a/src/utils/definition-helpers.ts
+++ b/src/utils/definition-helpers.ts
@@ -6,6 +6,7 @@ import { Location, Range } from 'vscode-languageserver/node';
 import { URI } from 'vscode-uri';
 
 import { isModuleUnificationApp, podModulePrefixForRoot, hasAddonFolderInPath, getProjectAddonsRoots, getProjectInRepoAddonsRoots } from './layout-helpers';
+import { logInfo } from './logger';
 
 const mProjectAddonsRoots = memoize(getProjectAddonsRoots, {
   length: 1,
@@ -71,11 +72,14 @@ export function getAbstractParts(root: string, prefix: string, collection: strin
   ];
 }
 
-export function getAbstractPartsWithTemplates(root: string, prefix: string, collection: string, name: string) {
+export function getAbstractPartsWithTemplates(root: string, prefix: string, collection: string[]) {
+  const importParts = [...collection];
+  const name = importParts.pop();
+
   return [
-    [root, prefix, collection, `${name}.js`],
-    [root, prefix, collection, `${name}.ts`],
-    [root, prefix, collection, `${name}.hbs`],
+    [root, prefix, ...importParts, `${name}.js`],
+    [root, prefix, ...importParts, `${name}.ts`],
+    [root, prefix, ...importParts, `${name}.hbs`],
   ];
 }
 
@@ -173,9 +177,9 @@ export function getAddonImport(root: string, importPath: string) {
 
     const addonPaths: string[][] = [];
     const possibleLocations = [
-      [rootPath, 'app', ...importParts],
-      [rootPath, 'addon', ...importParts],
-      [rootPath, ...importParts],
+      [rootPath, 'app', importParts],
+      [rootPath, 'addon', importParts],
+      [rootPath, '', importParts],
     ];
 
     possibleLocations.forEach((locationArr: Parameters<typeof getAbstractPartsWithTemplates>) => {

--- a/src/utils/definition-helpers.ts
+++ b/src/utils/definition-helpers.ts
@@ -6,7 +6,6 @@ import { Location, Range } from 'vscode-languageserver/node';
 import { URI } from 'vscode-uri';
 
 import { isModuleUnificationApp, podModulePrefixForRoot, hasAddonFolderInPath, getProjectAddonsRoots, getProjectInRepoAddonsRoots } from './layout-helpers';
-import { logInfo } from './logger';
 
 const mProjectAddonsRoots = memoize(getProjectAddonsRoots, {
   length: 1,

--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -2367,6 +2367,42 @@ Object {
 }
 `;
 
+exports[`integration Go to definition works for all supported cases go to definition from app to nested utils location of in repo addon 1`] = `
+Object {
+  "addonsMeta": Array [
+    Object {
+      "name": "biz",
+      "root": "lib/biz",
+    },
+  ],
+  "registry": Object {
+    "component": Object {
+      "darling": Array [
+        "app/components/darling/index.js",
+      ],
+      "hello": Array [
+        "app/components/hello.js",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/lib/biz/addon/utils/boo/blah/zoo/bar.js",
+    },
+  ],
+}
+`;
+
 exports[`integration Go to definition works for all supported cases go to definition from handlebars template working if we have test for component 1`] = `
 Object {
   "addonsMeta": Array [],

--- a/test/bultin-addons/core/template-complation-provider-test.ts
+++ b/test/bultin-addons/core/template-complation-provider-test.ts
@@ -34,8 +34,6 @@ describe('generateNamespacedComponentsHashMap', function () {
     };
 
     expect(generateNamespacedComponentsHashMap(mockAddonMetaArr, server, true)).toEqual({ Foo: ['Biz$Foo'] });
-
-    console.log('suchita doshi', generateNamespacedComponentsHashMap(mockAddonMetaArr, server, true));
   });
 
   it('[Mustache] returns the expected namespaced map', function () {

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -197,6 +197,61 @@ describe('integration', function () {
 
       expect(result).toMatchSnapshot();
     });
+    it('go to definition from app to nested utils location of in repo addon', async () => {
+      const result = await getResult(
+        DefinitionRequest.method,
+        connection,
+        {
+          app: {
+            components: {
+              'hello.js': 'import Bar from "biz/utils/boo/blah/zoo/bar"',
+              darling: {
+                'index.js': '',
+              },
+            },
+          },
+          lib: {
+            biz: {
+              addon: {
+                utils: {
+                  boo: {
+                    blah: {
+                      zoo: {
+                        'bar.js': '',
+                      },
+                    },
+                  },
+                },
+              },
+              'package.json': JSON.stringify({
+                name: 'biz',
+                keywords: ['ember-addon'],
+                dependencies: {},
+              }),
+              'index.js': `/* eslint-env node */
+              'use strict';
+              
+              module.exports = {
+                name: 'biz',
+              
+                isDevelopingAddon() {
+                  return true;
+                }
+              };`,
+            },
+          },
+          'package.json': JSON.stringify({
+            'ember-addon': {
+              paths: ['lib/biz'],
+            },
+          }),
+        },
+        'app/components/hello.js',
+        { line: 0, character: 8 }
+      );
+
+      expect(result).toMatchSnapshot();
+    });
     it('go to local template-only component in module', async () => {
       const result = await getResult(
         DefinitionRequest.method,


### PR DESCRIPTION
Context:
Currently we are limiting the imports to be of specific length. Eg: `import Foo from 'bar/utils/boo/biz/box/blah.js'` gets evaluated as `bar/utils/boo/biz` only.
This PR ensures we are considering the whole path instead a strict number of nested path