### PR TITLE
Support `workspace/didChangeConfiguration` event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 coverage
 inst/
 .nyc_output
+
+# Debug Logging
+debug.log

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,9 +55,10 @@ import { URI } from 'vscode-uri';
 import { MatchResultType } from './utils/path-matcher';
 import { FileChangeType } from 'vscode-languageserver/node';
 import { debounce } from 'lodash';
+import { Initializer } from './types';
 
 export default class Server {
-  initializers: any[] = [];
+  initializers: Initializer[] = [];
   lazyInit = false;
   // Create a connection for the server. The connection defaults to Node's IPC as a transport, but
   // also supports stdio via command line flag
@@ -129,7 +130,7 @@ export default class Server {
   referenceProvider: ReferenceProvider = new ReferenceProvider(this);
   codeActionProvider: CodeActionProvider = new CodeActionProvider(this);
   executeInitializers() {
-    this.initializers.forEach((cb: any) => cb());
+    this.initializers.forEach((cb) => cb());
     this.initializers = [];
   }
   private onInitialized() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type Initializer = () => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,7 @@
 export type Initializer = () => void;
+
+export interface Config {
+  addons: string[];
+  ignoredProjects: string[];
+  useBuiltinLinting: boolean;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,10 +1,13 @@
 import * as fs from 'fs';
 import * as util from 'util';
+import { resolve } from 'path';
 
 import { RemoteConsole } from 'vscode-languageserver/node';
 
-const debug = false;
-const log_file = debug ? fs.createWriteStream(__dirname + '/debug.log', { flags: 'w' }) : null;
+// Log debugging to the ELS package root, if possible
+const debug = process.env.ELS_DEBUG || false;
+const log_file = debug ? fs.createWriteStream(resolve(__dirname, '../../debug.log'), { flags: 'w' }) : null;
+
 let remoteConsole: RemoteConsole | null = null;
 
 export function logError(err: any) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -46,16 +46,16 @@ export function safeStringify(obj: unknown, indent = 2) {
   return retVal;
 }
 
-export function log(...args: any[]) {
-  if (!debug || !log_file) {
-    return;
+export function log(...args: unknown[]) {
+  const output = args.map((a) => safeStringify(a)).join(' ');
+
+  if (remoteConsole) {
+    remoteConsole.log(output);
   }
 
-  const output = args
-    .map((a: any) => {
-      return safeStringify(a);
-    })
-    .join(' ');
+  if (!log_file) {
+    return;
+  }
 
   log_file.write('----------------------------------------' + '\r\n');
   log_file.write(util.format(output) + '\r\n');


### PR DESCRIPTION
This updates the server to support the `workspace/didChangeConfiguration` event, which allows other language server clients to set configuration options in a conventional way

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeConfiguration

With this change, `nvim-lsp` is able to configure all of the options without having to do something custom to trigger the `els.setConfig` command; it "just works"!

I put a few other refactorings in here too; I can pull them into a separate PR if necessary. It was really hard to actually find the debug log because it was sent to the `lib` directory with the TypeScript output, which is _not_ a location I thought to look. Now the debug log appears right in the root of the package while you're working on it!