### PR TITLE
improve template tokenization

### DIFF
--- a/test/utils/registry-api-test.ts
+++ b/test/utils/registry-api-test.ts
@@ -24,13 +24,16 @@ const knownRegistryKeys = ['transform', 'helper', 'component', 'routePath', 'mod
 describe('addToRegistry - it able to add different kinds to registry', () => {
   const files = [];
 
-  it('able to add different file types to same kind', () => {
+  it('able to add different file types to same kind', async () => {
     const file1 = createFile('foo-bar.hbs', '<div><Boo /></div>');
     const file2 = createFile('foo-bar.js', '');
     const file3 = createFile('foo-bar.css', '');
 
     files.push(file1, file2, file3);
     addToRegistry('foo-bar', 'component', files);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
     expect(getRegistryForRoot(path.resolve(dir.path()))['component']['foo-bar'].length).toBe(3);
     expect(findRelatedFiles('boo').length).toBe(1);
   });

--- a/test/utils/usages-api-test.ts
+++ b/test/utils/usages-api-test.ts
@@ -25,10 +25,12 @@ describe('Usages API', () => {
     expect(closestParentRoutePath('foo-error')).toBe('foo');
     expect(closestParentRoutePath('foo/bar/baz')).toBe('foo/bar');
   });
-  it('should extract component template tokens by giving path', () => {
+  it('should extract component template tokens by giving path', async () => {
     expect(findRelatedFiles('foo-bar').length).toBe(0);
 
     updateTemplateTokens('component', 'foo', createFile('foo.hbs', '<FooBar />'));
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(findRelatedFiles('foo-bar').length).toBe(1);
 
@@ -36,11 +38,13 @@ describe('Usages API', () => {
 
     expect(findRelatedFiles('foo-bar').length).toBe(0);
   });
-  it('should extract component template tokens by giving path for different kinds', () => {
+  it('should extract component template tokens by giving path for different kinds',  async () => {
     expect(findRelatedFiles('foo-bar').length).toBe(0);
 
     updateTemplateTokens('component', 'foo', createFile('foo.hbs', '<FooBar />'));
     updateTemplateTokens('routePath', 'boo', createFile('boo.hbs', '{{foo-bar}}'));
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(findRelatedFiles('foo-bar').length).toBe(2);
 
@@ -49,39 +53,45 @@ describe('Usages API', () => {
 
     expect(findRelatedFiles('foo-bar').length).toBe(0);
   });
-  it('should return usages for closest routes (upper)', () => {
+  it('should return usages for closest routes (upper)', async () => {
     expect(findRelatedFiles('foo/bar/baz', 'template').length).toBe(0);
     updateTemplateTokens('routePath', 'foo.bar', createFile('bar.hbs', ''));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(findRelatedFiles('foo/bar/baz', 'template').length).toBe(1);
     updateTemplateTokens('routePath', 'foo.bar', null);
   });
-  it('should return usages for closest available routes (upper)', () => {
+  it('should return usages for closest available routes (upper)', async () => {
     expect(findRelatedFiles('foo/bar/baz', 'template').length).toBe(0);
     updateTemplateTokens('routePath', 'foo', createFile('bar.hbs', ''));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(findRelatedFiles('foo/bar/baz', 'template').length).toBe(1);
     updateTemplateTokens('routePath', 'foo', null);
   });
-  it('should return usages for closest available routes, in index case', () => {
+  it('should return usages for closest available routes, in index case', async () => {
     expect(findRelatedFiles('index', 'template').length).toBe(0);
     updateTemplateTokens('routePath', 'application', createFile('bar.hbs', ''));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(findRelatedFiles('index', 'template').length).toBe(1);
     updateTemplateTokens('routePath', 'application', null);
   });
-  it('should return usages for closest available routes, in loading case', () => {
+  it('should return usages for closest available routes, in loading case', async () => {
     expect(findRelatedFiles('index-loading', 'template').length).toBe(0);
     updateTemplateTokens('routePath', 'index', createFile('bar.hbs', ''));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(findRelatedFiles('index-loading', 'template').length).toBe(1);
     updateTemplateTokens('routePath', 'index', null);
   });
-  it('should return usages for closest available routes, in error case', () => {
+  it('should return usages for closest available routes, in error case', async () => {
     expect(findRelatedFiles('index-error', 'template').length).toBe(0);
     updateTemplateTokens('routePath', 'index', createFile('bar.hbs', ''));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(findRelatedFiles('index-error', 'template').length).toBe(1);
     updateTemplateTokens('routePath', 'index', null);
   });
-  it('should return root template for case if no parents by path', () => {
+  it('should return root template for case if no parents by path', async () => {
     expect(findRelatedFiles('groups-loading', 'template').length).toBe(0);
     updateTemplateTokens('routePath', 'application', createFile('bar.hbs', ''));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(findRelatedFiles('groups-loading', 'template').length).toBe(1);
     updateTemplateTokens('routePath', 'application', null);
   });

--- a/test/utils/usages-api-test.ts
+++ b/test/utils/usages-api-test.ts
@@ -38,7 +38,7 @@ describe('Usages API', () => {
 
     expect(findRelatedFiles('foo-bar').length).toBe(0);
   });
-  it('should extract component template tokens by giving path for different kinds',  async () => {
+  it('should extract component template tokens by giving path for different kinds', async () => {
     expect(findRelatedFiles('foo-bar').length).toBe(0);
 
     updateTemplateTokens('component', 'foo', createFile('foo.hbs', '<FooBar />'));


### PR DESCRIPTION
In general, this MR should improve project initialization speed, because during project files lookup we trying to do template tokenization, likely it should be performed in a side thread, but for now we trying to unblock runloop to schedule it for later

- [ ] also, it will be great to create promise-based test helper for it

related to https://github.com/lifeart/ember-language-server/issues/261

mayfix https://github.com/lifeart/ember-language-server/issues/260

in addition, we could have checkbox for LS configuration to disable usages lookup at all 