### PR TITLE
chore: extra filtering over project roots

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -44,10 +44,14 @@ export class Project {
   @cached
   get roots() {
     const mainRoot = this.root;
-    const otherRoots = this.addonsMeta.map((meta) => meta.root);
+    const otherRoots = this.addonsMeta.filter((addon) => addon.version !== null).map((meta) => meta.root);
+    const ignoredParts = ['node_modules'];
+    const filteredRoots = otherRoots.filter((el) => {
+      return ignoredParts.every((part) => !el.includes(part));
+    });
     // because all registry searches based on "startsWith", we could omit roots in same namespace,
     // like {root/a, root/b}, because we will get results of it from {root} itself
-    const differentRoots = otherRoots.filter((root) => !isRootStartingWithFilePath(root, mainRoot));
+    const differentRoots = filteredRoots.filter((root) => !isRootStartingWithFilePath(root, mainRoot));
 
     return [mainRoot, ...differentRoots];
   }


### PR DESCRIPTION
This mr fixes behavour there in project roots we have els addons and addons, located inside node_modules, we should not rely on it, because there is no use-case where we edit node_modules internals, and els addons should not side on behavour, related to project.roots

should improve performance for fs-based lookups

fixes https://github.com/lifeart/ember-language-server/issues/264
