### PR TITLE
feat: remove pure component name lookup prior to path matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.2.1",
     "source-map-support": "^0.5.19",
-    "ts-jest": "^26.4.4",
+    "ts-jest": "^26.5.6",
     "ts-loader": "^8.0.14",
     "ts-node": "^8.10.2",
     "typescript": "^4.1.3",

--- a/src/base-project.ts
+++ b/src/base-project.ts
@@ -1,0 +1,23 @@
+import { getPodModulePrefix } from './utils/layout-helpers';
+import { ClassicPathMatcher, PodMatcher } from './utils/path-matcher';
+
+export class BaseProject {
+  private classicMatcher!: ClassicPathMatcher;
+  private podMatcher!: PodMatcher;
+  podModulePrefix = '';
+  constructor(public readonly root: string) {
+    const maybePrefix = getPodModulePrefix(root);
+
+    if (maybePrefix) {
+      this.podModulePrefix = 'app/' + maybePrefix;
+    } else {
+      this.podModulePrefix = 'app';
+    }
+
+    this.classicMatcher = new ClassicPathMatcher(this.root);
+    this.podMatcher = new PodMatcher(this.root, this.podModulePrefix);
+  }
+  matchPathToType(filePath: string) {
+    return this.classicMatcher.metaFromPath(filePath) || this.podMatcher.metaFromPath(filePath);
+  }
+}

--- a/src/builtin-addons/core/script-completion-provider.ts
+++ b/src/builtin-addons/core/script-completion-provider.ts
@@ -48,9 +48,9 @@ export default class ScriptCompletionProvider {
       try {
         const initStartTime = Date.now();
 
-        mListModels(project.root);
+        mListModels(project);
         this.enableRegistryCache('modelsRegistryInitialized');
-        mListServices(project.root);
+        mListServices(project);
         this.enableRegistryCache('servicesRegistryInitialized');
         logInfo(project.root + ': script registry initialized in ' + (Date.now() - initStartTime) + 'ms');
       } catch (e) {
@@ -75,7 +75,7 @@ export default class ScriptCompletionProvider {
         log('isStoreModelLookup || isModelReference');
 
         if (!this.meta.modelsRegistryInitialized) {
-          mListModels(root);
+          mListModels(this.project);
           this.enableRegistryCache('modelsRegistryInitialized');
         }
 
@@ -97,7 +97,7 @@ export default class ScriptCompletionProvider {
         log('isRouteLookup');
 
         if (!this.meta.routesRegistryInitialized) {
-          mListRoutes(root);
+          mListRoutes(this.project);
           this.enableRegistryCache('routesRegistryInitialized');
         }
 
@@ -119,7 +119,7 @@ export default class ScriptCompletionProvider {
         log('isNamedServiceInjection');
 
         if (!this.meta.servicesRegistryInitialized) {
-          mListServices(root);
+          mListServices(this.project);
           this.enableRegistryCache('servicesRegistryInitialized');
         }
 
@@ -173,7 +173,7 @@ export default class ScriptCompletionProvider {
         log('isTransformReference');
 
         if (!this.meta.transformsRegistryInitialized) {
-          mListTransforms(root);
+          mListTransforms(this.project);
           this.enableRegistryCache('transformsRegistryInitialized');
         }
 

--- a/src/builtin-addons/core/template-completion-provider.ts
+++ b/src/builtin-addons/core/template-completion-provider.ts
@@ -155,13 +155,13 @@ export default class TemplateCompletionProvider {
       try {
         const initStartTime = Date.now();
 
-        mListHelpers(project.root);
+        mListHelpers(project);
         this.enableRegistryCache('helpersRegistryInitialized');
 
-        mListModifiers(project.root);
+        mListModifiers(project);
         this.enableRegistryCache('modifiersRegistryInitialized');
 
-        mListRoutes(project.root);
+        mListRoutes(project);
         this.enableRegistryCache('routesRegistryInitialized');
 
         mListComponents(project);
@@ -253,7 +253,7 @@ export default class TemplateCompletionProvider {
     }
 
     if (!this.meta.helpersRegistryInitialized) {
-      mListHelpers(root);
+      mListHelpers(this.project);
       this.enableRegistryCache('helpersRegistryInitialized');
     }
 
@@ -304,14 +304,14 @@ export default class TemplateCompletionProvider {
       };
     });
   }
-  getSubExpressionPathCandidates(root: string) {
+  getSubExpressionPathCandidates() {
     if (!this.meta.helpersRegistryInitialized) {
-      mListHelpers(root);
+      mListHelpers(this.project);
       this.enableRegistryCache('helpersRegistryInitialized');
     }
 
     if (!this.meta.projectAddonsInfoInitialized) {
-      mGetProjectAddonsInfo(root);
+      mGetProjectAddonsInfo(this.project.root);
       this.enableRegistryCache('projectAddonsInfoInitialized');
     }
 
@@ -495,7 +495,7 @@ export default class TemplateCompletionProvider {
       } else if (isSubExpressionPath(focusPath)) {
         // {{foo-bar name=(subexpr? )}}
         log('isSubExpressionPath');
-        const candidates = this.getSubExpressionPathCandidates(root);
+        const candidates = this.getSubExpressionPathCandidates();
 
         completions.push(...uniqBy(candidates, 'label'));
         completions.push(...emberSubExpressionItems);
@@ -514,7 +514,7 @@ export default class TemplateCompletionProvider {
         log('isLinkToTarget');
 
         if (!this.meta.routesRegistryInitialized) {
-          mListRoutes(root);
+          mListRoutes(this.project);
           this.enableRegistryCache('routesRegistryInitialized');
         }
 
@@ -534,7 +534,7 @@ export default class TemplateCompletionProvider {
         log('isLinkComponentRouteTarget');
 
         if (!this.meta.routesRegistryInitialized) {
-          mListRoutes(root);
+          mListRoutes(this.project);
           this.enableRegistryCache('routesRegistryInitialized');
         }
 
@@ -553,7 +553,7 @@ export default class TemplateCompletionProvider {
         log('isModifierPath');
 
         if (!this.meta.modifiersRegistryInitialized) {
-          mListModifiers(root);
+          mListModifiers(this.project);
           this.enableRegistryCache('modifiersRegistryInitialized');
         }
 

--- a/src/builtin-addons/core/template-completion-provider.ts
+++ b/src/builtin-addons/core/template-completion-provider.ts
@@ -37,6 +37,7 @@ import {
   hasNamespaceSupport,
   isRootStartingWithFilePath,
   isScriptPath,
+  isTestFile,
 } from '../../utils/layout-helpers';
 
 import { normalizeToAngleBracketComponent } from '../../utils/normalizers';
@@ -45,7 +46,6 @@ import { ASTNode } from 'ast-types';
 import { ASTv1 } from '@glimmer/syntax';
 import { URI } from 'vscode-uri';
 import { componentsContextData } from './template-context-provider';
-import { isTestFile } from '../../utils/layout-helpers';
 
 const mListModifiers = memoize(listModifiers, { length: 1, maxAge: 60000 }); // 1 second
 const mListComponents = memoize(listComponents, { length: 1, maxAge: 60000 }); // 1 second

--- a/src/builtin-addons/core/template-context-provider.ts
+++ b/src/builtin-addons/core/template-context-provider.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 
-import { isModuleUnificationApp, podModulePrefixForRoot, pureComponentName } from '../../utils/layout-helpers';
+import { isModuleUnificationApp, podModulePrefixForRoot } from '../../utils/layout-helpers';
 import { getGlobalRegistry } from '../../utils/registry-api';
 import { log } from '../../utils/logger';
 
@@ -18,19 +18,6 @@ function localizeName(name: string) {
   } else {
     return 'this.' + name;
   }
-}
-
-export function templateContextLookup(root: string, rawCurrentFilePath: string, templateContent: string) {
-  const currentFilePath = rawCurrentFilePath.replace('file://', '').split('\\').join('/');
-  const nameParts = currentFilePath.split('/components/');
-
-  if (nameParts.length !== 2) {
-    return [];
-  }
-
-  const componentName = pureComponentName(nameParts[1].split('.')[0]);
-
-  return componentsContextData(root, componentName, templateContent);
 }
 
 function findComponentScripts(root: string, componentName: string) {
@@ -68,15 +55,14 @@ function findComponentScripts(root: string, componentName: string) {
   return possibleLocations.map((locArr: string[]) => path.join.apply(null, locArr));
 }
 
-function componentsContextData(root: string, componentName: string, templateContent: string): CompletionItem[] {
-  const maybeScripts = findComponentScripts(root, componentName);
+export function componentsContextData(maybeScripts: string[], templateContent: string): CompletionItem[] {
   const existingScripts = maybeScripts.filter(fs.existsSync);
   const hasAddonScript = existingScripts.find((el) => el.includes('addon'));
   const infoItems: IJsMeta[] = [];
 
   if (existingScripts.length) {
     try {
-      const filePath = hasAddonScript ? hasAddonScript : existingScripts.pop();
+      const filePath = hasAddonScript ? hasAddonScript : (existingScripts.pop() as string);
       const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
       const jsMeta = processJSFile(fileContent, filePath);
 

--- a/src/builtin-addons/core/template-context-provider.ts
+++ b/src/builtin-addons/core/template-context-provider.ts
@@ -1,9 +1,6 @@
-import * as path from 'path';
 import * as fs from 'fs';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 
-import { isModuleUnificationApp, podModulePrefixForRoot } from '../../utils/layout-helpers';
-import { getGlobalRegistry } from '../../utils/registry-api';
 import { log } from '../../utils/logger';
 
 import { extractComponentInformationFromMeta, IComponentMetaInformation, IJsMeta, processJSFile, processTemplate } from 'ember-meta-explorer';
@@ -18,41 +15,6 @@ function localizeName(name: string) {
   } else {
     return 'this.' + name;
   }
-}
-
-function findComponentScripts(root: string, componentName: string) {
-  const possibleLocations = [];
-  const registry = getGlobalRegistry();
-
-  if (registry.component.has(componentName)) {
-    const els: string[] = Array.from((registry.component.get(componentName) as any).values());
-
-    els.forEach((el) => {
-      if (el.includes(root)) {
-        possibleLocations.push([el]);
-      }
-    });
-  }
-
-  if (isModuleUnificationApp(root)) {
-    possibleLocations.push([root, 'src', 'ui', 'components', componentName, 'component.js']);
-    possibleLocations.push([root, 'src', 'ui', 'components', componentName, 'component.ts']);
-  } else {
-    possibleLocations.push([root, 'app', 'components', componentName, 'component.js']);
-    possibleLocations.push([root, 'app', 'components', componentName, 'component.ts']);
-    possibleLocations.push([root, 'app', 'components', componentName, 'index.js']);
-    possibleLocations.push([root, 'app', 'components', componentName, 'index.ts']);
-    possibleLocations.push([root, 'app', 'components', componentName + '.js']);
-    possibleLocations.push([root, 'app', 'components', componentName + '.ts']);
-    const prefix = podModulePrefixForRoot(root);
-
-    if (prefix) {
-      possibleLocations.push([root, 'app', prefix, 'components', componentName, 'component.js']);
-      possibleLocations.push([root, 'app', prefix, 'components', componentName, 'component.ts']);
-    }
-  }
-
-  return possibleLocations.map((locArr: string[]) => path.join.apply(null, locArr));
 }
 
 export function componentsContextData(maybeScripts: string[], templateContent: string): CompletionItem[] {

--- a/src/project.ts
+++ b/src/project.ts
@@ -119,7 +119,7 @@ export class Project {
   get name() {
     return this.packageJSON.name;
   }
-  constructor(public readonly root: string, addons: string[]) {
+  constructor(public readonly root: string, addons: string[] = []) {
     this.providers = collectProjectProviders(root, addons);
     this.addonsMeta = this.providers.addonsMeta.filter((el) => el.root !== this.root);
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,6 +1,6 @@
 import { PodMatcher, ClassicPathMatcher } from './utils/path-matcher';
 import { addToRegistry, removeFromRegistry, normalizeMatchNaming, NormalizedRegistryItem } from './utils/registry-api';
-import { ProjectProviders, collectProjectProviders, initBuiltinProviders, AddonMeta, DependencyMeta } from './utils/addon-api';
+import { ProjectProviders, collectProjectProviders, AddonMeta, DependencyMeta } from './utils/addon-api';
 import {
   getPodModulePrefix,
   findTestsForProject,
@@ -18,6 +18,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as path from 'path';
 import { logError, logInfo } from './utils/logger';
 import { URI } from 'vscode-uri';
+import { initBuiltinProviders } from './utils/builtin-addons-initializer';
 
 export type Executor = (server: Server, command: string, args: unknown[]) => Promise<unknown>;
 export type Destructor = (project: Project) => void;

--- a/src/utils/addon-api.ts
+++ b/src/utils/addon-api.ts
@@ -14,16 +14,8 @@ import { log, logInfo, logError, safeStringify } from './logger';
 import Server from '../server';
 import ASTPath from './../glimmer-utils';
 import DAGMap from 'dag-map';
-import CoreScriptDefinitionProvider from './../builtin-addons/core/script-definition-provider';
-import CoreTemplateDefinitionProvider from './../builtin-addons/core/template-definition-provider';
-import ScriptCompletionProvider from './../builtin-addons/core/script-completion-provider';
-import TemplateCompletionProvider from './../builtin-addons/core/template-completion-provider';
+
 import { Project } from '../project';
-
-import TemplateLintFixesCodeAction from '../builtin-addons/core/code-actions/template-lint-fixes';
-import TemplateLintCommentsCodeAction from '../builtin-addons/core/code-actions/template-lint-comments';
-import TypedTemplatesCodeAction from '../builtin-addons/core/code-actions/typed-template-comments';
-
 interface BaseAPIParams {
   server: Server;
   textDocument: TextDocumentIdentifier;
@@ -96,38 +88,6 @@ export async function queryELSAddonsAPIChain(callbacks: any[], root: string, par
   }
 
   return lastResult;
-}
-
-export function initBuiltinProviders(): ProjectProviders {
-  const scriptDefinition = new CoreScriptDefinitionProvider();
-  const templateDefinition = new CoreTemplateDefinitionProvider();
-  const scriptCompletion = new ScriptCompletionProvider();
-  const templateCompletion = new TemplateCompletionProvider();
-
-  const templateLintFixesCodeAction = new TemplateLintFixesCodeAction();
-  const templateLintCommentsCodeAction = new TemplateLintCommentsCodeAction();
-  const typedTemplatesCodeAction = new TypedTemplatesCodeAction();
-
-  return {
-    definitionProviders: [scriptDefinition.onDefinition.bind(scriptDefinition), templateDefinition.onDefinition.bind(templateDefinition)],
-    referencesProviders: [],
-    codeActionProviders: [
-      templateLintFixesCodeAction.onCodeAction.bind(templateLintFixesCodeAction),
-      templateLintCommentsCodeAction.onCodeAction.bind(templateLintCommentsCodeAction),
-      typedTemplatesCodeAction.onCodeAction.bind(typedTemplatesCodeAction),
-    ],
-    initFunctions: [
-      templateLintFixesCodeAction.onInit.bind(templateLintFixesCodeAction),
-      templateLintCommentsCodeAction.onInit.bind(templateLintCommentsCodeAction),
-      typedTemplatesCodeAction.onInit.bind(typedTemplatesCodeAction),
-      templateCompletion.initRegistry.bind(templateCompletion),
-      scriptCompletion.initRegistry.bind(scriptCompletion),
-      templateDefinition.onInit.bind(templateDefinition),
-    ],
-    info: [],
-    addonsMeta: [],
-    completionProviders: [scriptCompletion.onComplete.bind(scriptCompletion), templateCompletion.onComplete.bind(templateCompletion)],
-  };
 }
 
 export function isConstructor(obj: any) {

--- a/src/utils/builtin-addons-initializer.ts
+++ b/src/utils/builtin-addons-initializer.ts
@@ -1,0 +1,40 @@
+import TemplateLintFixesCodeAction from '../builtin-addons/core/code-actions/template-lint-fixes';
+import TemplateLintCommentsCodeAction from '../builtin-addons/core/code-actions/template-lint-comments';
+import TypedTemplatesCodeAction from '../builtin-addons/core/code-actions/typed-template-comments';
+import CoreScriptDefinitionProvider from './../builtin-addons/core/script-definition-provider';
+import CoreTemplateDefinitionProvider from './../builtin-addons/core/template-definition-provider';
+import ScriptCompletionProvider from './../builtin-addons/core/script-completion-provider';
+import TemplateCompletionProvider from './../builtin-addons/core/template-completion-provider';
+import { ProjectProviders } from './addon-api';
+
+export function initBuiltinProviders(): ProjectProviders {
+  const scriptDefinition = new CoreScriptDefinitionProvider();
+  const templateDefinition = new CoreTemplateDefinitionProvider();
+  const scriptCompletion = new ScriptCompletionProvider();
+  const templateCompletion = new TemplateCompletionProvider();
+
+  const templateLintFixesCodeAction = new TemplateLintFixesCodeAction();
+  const templateLintCommentsCodeAction = new TemplateLintCommentsCodeAction();
+  const typedTemplatesCodeAction = new TypedTemplatesCodeAction();
+
+  return {
+    definitionProviders: [scriptDefinition.onDefinition.bind(scriptDefinition), templateDefinition.onDefinition.bind(templateDefinition)],
+    referencesProviders: [],
+    codeActionProviders: [
+      templateLintFixesCodeAction.onCodeAction.bind(templateLintFixesCodeAction),
+      templateLintCommentsCodeAction.onCodeAction.bind(templateLintCommentsCodeAction),
+      typedTemplatesCodeAction.onCodeAction.bind(typedTemplatesCodeAction),
+    ],
+    initFunctions: [
+      templateLintFixesCodeAction.onInit.bind(templateLintFixesCodeAction),
+      templateLintCommentsCodeAction.onInit.bind(templateLintCommentsCodeAction),
+      typedTemplatesCodeAction.onInit.bind(typedTemplatesCodeAction),
+      templateCompletion.initRegistry.bind(templateCompletion),
+      scriptCompletion.initRegistry.bind(scriptCompletion),
+      templateDefinition.onInit.bind(templateDefinition),
+    ],
+    info: [],
+    addonsMeta: [],
+    completionProviders: [scriptCompletion.onComplete.bind(scriptCompletion), templateCompletion.onComplete.bind(templateCompletion)],
+  };
+}

--- a/src/utils/definition-helpers.ts
+++ b/src/utils/definition-helpers.ts
@@ -8,7 +8,7 @@ import { URI } from 'vscode-uri';
 import { isModuleUnificationApp, podModulePrefixForRoot, hasAddonFolderInPath, getProjectAddonsRoots, getProjectInRepoAddonsRoots } from './layout-helpers';
 
 const mProjectAddonsRoots = memoize(getProjectAddonsRoots, {
-  length: 1,
+  length: 3,
   maxAge: 600000,
 });
 const mProjectInRepoAddonsRoots = memoize(getProjectInRepoAddonsRoots, {

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -3,9 +3,9 @@ import * as walkSync from 'walk-sync';
 import * as fs from 'fs';
 import * as path from 'path';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
-import { Project } from '../project';
 import { addToRegistry, normalizeMatchNaming } from './registry-api';
 import { clean, coerce, valid } from 'semver';
+import { BaseProject } from '../base-project';
 
 // const GLOBAL_REGISTRY = ['primitive-name'][['relatedFiles']];
 
@@ -434,7 +434,7 @@ export function getProjectAddonsInfo(root: string): void {
     }
 
     if (version === 1) {
-      const localProject = new Project(packagePath);
+      const localProject = new BaseProject(packagePath);
 
       listComponents(localProject);
       listRoutes(localProject);
@@ -447,7 +447,7 @@ export function getProjectAddonsInfo(root: string): void {
   });
 }
 
-export function listPodsComponents(project: Project): void {
+export function listPodsComponents(project: BaseProject): void {
   const podModulePrefix = podModulePrefixForRoot(project.root);
 
   if (podModulePrefix === null) {
@@ -486,7 +486,7 @@ export function hasNamespaceSupport(root: string) {
   return hasDep(pack, 'ember-holy-futuristic-template-namespacing-batman');
 }
 
-export function listComponents(project: Project): void {
+export function listComponents(project: BaseProject): void {
   // log('listComponents');
   const root = path.resolve(project.root);
   const scriptEntry = path.join(root, 'app', 'components');
@@ -548,7 +548,7 @@ export function listComponents(project: Project): void {
   });
 }
 
-function findRegistryItemsForProject(project: Project, prefix: string, globs: string[]): void {
+function findRegistryItemsForProject(project: BaseProject, prefix: string, globs: string[]): void {
   const entry = path.resolve(path.join(project.root, prefix));
   const paths = safeWalkSync(entry, {
     directories: false,
@@ -567,20 +567,20 @@ function findRegistryItemsForProject(project: Project, prefix: string, globs: st
   });
 }
 
-export function findTestsForProject(project: Project) {
+export function findTestsForProject(project: BaseProject) {
   findRegistryItemsForProject(project, 'tests', ['**/*.{js,ts}']);
 }
 
-export function findAppItemsForProject(project: Project) {
+export function findAppItemsForProject(project: BaseProject) {
   findRegistryItemsForProject(project, 'app', ['**/*.{js,ts,css,less,sass,hbs}']);
 }
 
-export function findAddonItemsForProject(project: Project) {
+export function findAddonItemsForProject(project: BaseProject) {
   findRegistryItemsForProject(project, 'addon', ['**/*.{js,ts,css,less,sass,hbs}']);
 }
 
 function listCollection(
-  project: Project,
+  project: BaseProject,
   prefix: 'app' | 'addon',
   collectionName: 'transforms' | 'modifiers' | 'services' | 'models' | 'helpers',
   detail: 'transform' | 'service' | 'model' | 'helper' | 'modifier'
@@ -601,27 +601,27 @@ function listCollection(
   });
 }
 
-export function listModifiers(project: Project): void {
+export function listModifiers(project: BaseProject): void {
   return listCollection(project, 'app', 'modifiers', 'modifier');
 }
 
-export function listModels(project: Project): void {
+export function listModels(project: BaseProject): void {
   return listCollection(project, 'app', 'models', 'model');
 }
 
-export function listServices(project: Project): void {
+export function listServices(project: BaseProject): void {
   return listCollection(project, 'app', 'services', 'service');
 }
 
-export function listHelpers(project: Project): void {
+export function listHelpers(project: BaseProject): void {
   return listCollection(project, 'app', 'helpers', 'helper');
 }
 
-export function listTransforms(project: Project): void {
+export function listTransforms(project: BaseProject): void {
   return listCollection(project, 'app', 'transforms', 'transform');
 }
 
-export function listRoutes(project: Project): void {
+export function listRoutes(project: BaseProject): void {
   const root = path.resolve(project.root);
   const scriptEntry = path.join(root, 'app', 'routes');
   const templateEntry = path.join(root, 'app', 'templates');

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -32,15 +32,6 @@ export const mGetProjectAddonsInfo = memoize(getProjectAddonsInfo, {
   maxAge: 600000,
 }); // 1 second
 
-const mProjectAddonsRoots = memoize(getProjectAddonsRoots, {
-  length: 3,
-  maxAge: 600000,
-});
-const mProjectInRepoAddonsRoots = memoize(getProjectInRepoAddonsRoots, {
-  length: 1,
-  maxAge: 600000,
-});
-
 export const isAddonRoot = memoize(isProjectAddonRoot, {
   length: 1,
   maxAge: 600000,
@@ -429,7 +420,9 @@ export function hasAddonFolderInPath(name: string) {
 }
 
 export function getProjectAddonsInfo(root: string): void {
-  const roots = ([] as string[]).concat(mProjectAddonsRoots(root), mProjectInRepoAddonsRoots(root)).filter((pathItem: unknown) => typeof pathItem === 'string');
+  const roots = ([] as string[])
+    .concat(getProjectAddonsRoots(root), getProjectInRepoAddonsRoots(root))
+    .filter((pathItem: unknown) => typeof pathItem === 'string');
 
   roots.forEach((packagePath: string) => {
     const info = getPackageJSON(packagePath);

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -33,7 +33,7 @@ export const mGetProjectAddonsInfo = memoize(getProjectAddonsInfo, {
 }); // 1 second
 
 const mProjectAddonsRoots = memoize(getProjectAddonsRoots, {
-  length: 1,
+  length: 3,
   maxAge: 600000,
 });
 const mProjectInRepoAddonsRoots = memoize(getProjectInRepoAddonsRoots, {

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -441,48 +441,27 @@ export function getProjectAddonsInfo(root: string): void {
     }
 
     if (version === 1) {
-      listComponents(packagePath);
-      listRoutes(packagePath);
-      listHelpers(packagePath);
-      listModels(packagePath);
-      listTransforms(packagePath);
-      listServices(packagePath);
-      listModifiers(packagePath);
+      const localProject = new Project(packagePath);
+
+      listComponents(localProject);
+      listRoutes(localProject);
+      listHelpers(localProject);
+      listModels(localProject);
+      listTransforms(localProject);
+      listServices(localProject);
+      listModifiers(localProject);
     }
   });
 }
 
-// todo - remove pureComponent name usage here prior to project.matchPathToType
-export function pureComponentName(relativePath: string) {
-  const ext = path.extname(relativePath); // .hbs
-
-  if (relativePath.startsWith('/')) {
-    relativePath = relativePath.slice(1);
-  }
-
-  if (relativePath.endsWith(`/template${ext}`)) {
-    return relativePath.replace(`/template${ext}`, '');
-  } else if (relativePath.endsWith(`/component${ext}`)) {
-    return relativePath.replace(`/component${ext}`, '');
-  } else if (relativePath.endsWith(`/helper${ext}`)) {
-    return relativePath.replace(`/helper${ext}`, '');
-  } else if (relativePath.endsWith(`/index${ext}`)) {
-    return relativePath.replace(`/index${ext}`, '');
-  } else if (relativePath.endsWith(`/styles${ext}`)) {
-    return relativePath.replace(`/styles${ext}`, '');
-  } else {
-    return relativePath.replace(ext, '');
-  }
-}
-
-export function listPodsComponents(root: string): void {
-  const podModulePrefix = podModulePrefixForRoot(root);
+export function listPodsComponents(project: Project): void {
+  const podModulePrefix = podModulePrefixForRoot(project.root);
 
   if (podModulePrefix === null) {
     return;
   }
 
-  const entryPath = path.resolve(path.join(root, 'app', podModulePrefix, 'components'));
+  const entryPath = path.resolve(path.join(project.root, 'app', podModulePrefix, 'components'));
 
   const jsPaths = safeWalkSync(entryPath, {
     directories: false,
@@ -490,28 +469,12 @@ export function listPodsComponents(root: string): void {
   });
 
   jsPaths.forEach((filePath: string) => {
-    addToRegistry(pureComponentName(filePath), 'component', [path.join(entryPath, filePath)]);
+    const data = project.matchPathToType(filePath);
+
+    if (data?.type === 'component') {
+      addToRegistry(data.name, data.type, [path.join(entryPath, filePath)]);
+    }
   });
-}
-
-export function listMUComponents(root: string): CompletionItem[] {
-  const entryPath = path.resolve(path.join(root, 'src', 'ui', 'components'));
-  const jsPaths = safeWalkSync(entryPath, {
-    directories: false,
-    globs: ['**/*.{js,ts,hbs}'],
-  });
-
-  const items = jsPaths.map((filePath: string) => {
-    addToRegistry(pureComponentName(filePath), 'component', [path.join(entryPath, filePath)]);
-
-    return {
-      kind: CompletionItemKind.Class,
-      label: pureComponentName(filePath),
-      detail: 'component',
-    };
-  });
-
-  return items;
 }
 
 export function builtinModifiers(): CompletionItem[] {
@@ -530,9 +493,9 @@ export function hasNamespaceSupport(root: string) {
   return hasDep(pack, 'ember-holy-futuristic-template-namespacing-batman');
 }
 
-export function listComponents(_root: string): void {
+export function listComponents(project: Project): void {
   // log('listComponents');
-  const root = path.resolve(_root);
+  const root = path.resolve(project.root);
   const scriptEntry = path.join(root, 'app', 'components');
   const templateEntry = path.join(root, 'app', 'templates', 'components');
   const addonComponents = path.join(root, 'addon', 'components');
@@ -547,10 +510,20 @@ export function listComponents(_root: string): void {
   });
 
   addonComponentsPaths.forEach((p) => {
-    addToRegistry(pureComponentName(p), 'component', [path.join(addonComponents, p)]);
+    const fsPath = path.join(addonComponents, p);
+    const name = project.matchPathToType(fsPath)?.name;
+
+    if (name) {
+      addToRegistry(name, 'component', [fsPath]);
+    }
   });
   addonTemplatesPaths.forEach((p) => {
-    addToRegistry(pureComponentName(p), 'component', [path.join(addonTemplates, p)]);
+    const fsPath = path.join(addonTemplates, p);
+    const name = project.matchPathToType(fsPath)?.name;
+
+    if (name) {
+      addToRegistry(name, 'component', [fsPath]);
+    }
   });
 
   const jsPaths = safeWalkSync(scriptEntry, {
@@ -559,7 +532,12 @@ export function listComponents(_root: string): void {
   });
 
   jsPaths.forEach((p) => {
-    addToRegistry(pureComponentName(p), 'component', [path.join(scriptEntry, p)]);
+    const fsPath = path.join(scriptEntry, p);
+    const name = project.matchPathToType(fsPath)?.name;
+
+    if (name) {
+      addToRegistry(name, 'component', [fsPath]);
+    }
   });
 
   const hbsPaths = safeWalkSync(templateEntry, {
@@ -568,7 +546,12 @@ export function listComponents(_root: string): void {
   });
 
   hbsPaths.forEach((p) => {
-    addToRegistry(pureComponentName(p), 'component', [path.join(templateEntry, p)]);
+    const fsPath = path.join(templateEntry, p);
+    const name = project.matchPathToType(fsPath)?.name;
+
+    if (name) {
+      addToRegistry(name, 'component', [fsPath]);
+    }
   });
 }
 
@@ -604,53 +587,50 @@ export function findAddonItemsForProject(project: Project) {
 }
 
 function listCollection(
-  root: string,
+  project: Project,
   prefix: 'app' | 'addon',
   collectionName: 'transforms' | 'modifiers' | 'services' | 'models' | 'helpers',
   kindType: CompletionItemKind,
   detail: 'transform' | 'service' | 'model' | 'helper' | 'modifier'
 ) {
-  const entry = path.resolve(path.join(root, prefix, collectionName));
+  const entry = path.resolve(path.join(project.root, prefix, collectionName));
   const paths = safeWalkSync(entry, {
     directories: false,
     globs: ['**/*.{js,ts}'],
   });
 
-  const items = paths.map((filePath: string) => {
-    addToRegistry(pureComponentName(filePath), detail, [path.join(entry, filePath)]);
+  paths.forEach((filePath: string) => {
+    const fsPath = path.join(entry, filePath);
+    const data = project.matchPathToType(fsPath);
 
-    return {
-      kind: kindType,
-      label: pureComponentName(filePath),
-      detail,
-    };
+    if (data && data.type === detail) {
+      addToRegistry(data.name, detail, [fsPath]);
+    }
   });
-
-  return items;
 }
 
-export function listModifiers(root: string): CompletionItem[] {
-  return listCollection(root, 'app', 'modifiers', CompletionItemKind.Function, 'modifier');
+export function listModifiers(project: Project): void {
+  return listCollection(project, 'app', 'modifiers', CompletionItemKind.Function, 'modifier');
 }
 
-export function listModels(root: string): CompletionItem[] {
-  return listCollection(root, 'app', 'models', CompletionItemKind.Class, 'model');
+export function listModels(project: Project): void {
+  return listCollection(project, 'app', 'models', CompletionItemKind.Class, 'model');
 }
 
-export function listServices(root: string): CompletionItem[] {
-  return listCollection(root, 'app', 'services', CompletionItemKind.Class, 'service');
+export function listServices(project: Project): void {
+  return listCollection(project, 'app', 'services', CompletionItemKind.Class, 'service');
 }
 
-export function listHelpers(root: string): CompletionItem[] {
-  return listCollection(root, 'app', 'helpers', CompletionItemKind.Function, 'helper');
+export function listHelpers(project: Project): void {
+  return listCollection(project, 'app', 'helpers', CompletionItemKind.Function, 'helper');
 }
 
-export function listTransforms(root: string): CompletionItem[] {
-  return listCollection(root, 'app', 'transforms', CompletionItemKind.Function, 'transform');
+export function listTransforms(project: Project): void {
+  return listCollection(project, 'app', 'transforms', CompletionItemKind.Function, 'transform');
 }
 
-export function listRoutes(_root: string): void {
-  const root = path.resolve(_root);
+export function listRoutes(project: Project): void {
+  const root = path.resolve(project.root);
   const scriptEntry = path.join(root, 'app', 'routes');
   const templateEntry = path.join(root, 'app', 'templates');
   const controllersEntry = path.join(root, 'app', 'controllers');

--- a/src/utils/layout-helpers.ts
+++ b/src/utils/layout-helpers.ts
@@ -590,7 +590,6 @@ function listCollection(
   project: Project,
   prefix: 'app' | 'addon',
   collectionName: 'transforms' | 'modifiers' | 'services' | 'models' | 'helpers',
-  kindType: CompletionItemKind,
   detail: 'transform' | 'service' | 'model' | 'helper' | 'modifier'
 ) {
   const entry = path.resolve(path.join(project.root, prefix, collectionName));
@@ -610,23 +609,23 @@ function listCollection(
 }
 
 export function listModifiers(project: Project): void {
-  return listCollection(project, 'app', 'modifiers', CompletionItemKind.Function, 'modifier');
+  return listCollection(project, 'app', 'modifiers', 'modifier');
 }
 
 export function listModels(project: Project): void {
-  return listCollection(project, 'app', 'models', CompletionItemKind.Class, 'model');
+  return listCollection(project, 'app', 'models', 'model');
 }
 
 export function listServices(project: Project): void {
-  return listCollection(project, 'app', 'services', CompletionItemKind.Class, 'service');
+  return listCollection(project, 'app', 'services', 'service');
 }
 
 export function listHelpers(project: Project): void {
-  return listCollection(project, 'app', 'helpers', CompletionItemKind.Function, 'helper');
+  return listCollection(project, 'app', 'helpers', 'helper');
 }
 
 export function listTransforms(project: Project): void {
-  return listCollection(project, 'app', 'transforms', CompletionItemKind.Function, 'transform');
+  return listCollection(project, 'app', 'transforms', 'transform');
 }
 
 export function listRoutes(project: Project): void {

--- a/src/utils/path-matcher.ts
+++ b/src/utils/path-matcher.ts
@@ -85,6 +85,10 @@ export class ClassicPathMatcher {
       fullName = fullName.replace('-test', '');
     }
 
+    if (fullName.startsWith('./')) {
+      fullName = fullName.replace('./', '');
+    }
+
     return fullName;
   }
   metaFromPath(rawAbsoluteAbsPath: string): MatchResult | null {
@@ -159,6 +163,10 @@ export class PodMatcher extends ClassicPathMatcher {
 
     if (fullName.startsWith(componentFolderPath)) {
       fullName = fullName.replace(componentFolderPath, '');
+    }
+
+    if (fullName.startsWith('./')) {
+      fullName = fullName.replace('./', '');
     }
 
     return fullName;

--- a/test/utils/layout-helpers-test.ts
+++ b/test/utils/layout-helpers-test.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import { initFileStructure } from './../test_helpers/integration-helpers';
 import { getRegistryForRoot } from '../../src/utils/registry-api';
 import { Project } from '../../src/project';
+import { BaseProject } from '../../src/base-project';
 
 describe('definition-helpers', function () {
   describe('isMuApp()', function () {
@@ -77,7 +78,7 @@ describe('definition-helpers', function () {
     it('return expected list of components for classic project', function () {
       const root = path.join(__dirname, './../fixtures/full-project');
 
-      listComponents(root);
+      listComponents(new BaseProject(root));
 
       const keys = Object.keys(getRegistryForRoot(root).component);
 
@@ -93,9 +94,17 @@ describe('definition-helpers', function () {
 
   describe('listHelpers()', function () {
     it('return expected list of helpers for classic project', function () {
-      const components = listHelpers(path.join(__dirname, './../fixtures/full-project'));
+      const root = path.join(__dirname, './../fixtures/full-project');
 
-      expect(components.map(({ label }: { label: string }) => label)).toEqual(['some-helper']);
+      let keys = Object.keys(getRegistryForRoot(root).helper);
+
+      expect(keys.includes('some-helper')).toBe(false);
+
+      listHelpers(new BaseProject(root));
+
+      keys = Object.keys(getRegistryForRoot(root).helper);
+
+      expect(keys.includes('some-helper')).toBe(true);
     });
   });
 
@@ -103,7 +112,7 @@ describe('definition-helpers', function () {
     it('return expected list of routes for classic project', function () {
       const root = path.join(__dirname, './../fixtures/full-project');
 
-      listRoutes(root);
+      listRoutes(new BaseProject(root));
 
       const keys = Object.keys(getRegistryForRoot(root).routePath);
 

--- a/test/utils/layout-helpers-test.ts
+++ b/test/utils/layout-helpers-test.ts
@@ -4,9 +4,7 @@ import {
   safeWalkSync,
   resolvePackageRoot,
   getPackageJSON,
-  pureComponentName,
   listPodsComponents,
-  listMUComponents,
   listComponents,
   listHelpers,
   listRoutes,
@@ -18,6 +16,7 @@ import * as path from 'path';
 
 import { initFileStructure } from './../test_helpers/integration-helpers';
 import { getRegistryForRoot } from '../../src/utils/registry-api';
+import { Project } from '../../src/project';
 
 describe('definition-helpers', function () {
   describe('isMuApp()', function () {
@@ -57,23 +56,13 @@ describe('definition-helpers', function () {
     });
   });
 
-  describe('pureComponentName()', function () {
-    it('return component name without extension and layout postix', function () {
-      expect(pureComponentName('/foo/bar-baz.js')).toEqual('foo/bar-baz');
-      expect(pureComponentName('/foo/bar-baz.ts')).toEqual('foo/bar-baz');
-      expect(pureComponentName('/foo/bar-baz/component.js')).toEqual('foo/bar-baz');
-      expect(pureComponentName('/foo/bar-baz/component.ts')).toEqual('foo/bar-baz');
-      expect(pureComponentName('/foo/bar-baz/template.hbs')).toEqual('foo/bar-baz');
-      expect(pureComponentName('/foo/bar-baz.hbs')).toEqual('foo/bar-baz');
-      expect(pureComponentName('foo/bar-baz.hbs')).toEqual('foo/bar-baz');
-    });
-  });
-
   describe('listPodsComponents()', function () {
     it('return expected list of components for pods project', function () {
       const root = path.join(__dirname, './../fixtures/pod-project');
 
-      listPodsComponents(root);
+      const project = new Project(root);
+
+      listPodsComponents(project);
       const keys = Object.keys(getRegistryForRoot(root).component);
 
       const hasAllComponentsInRegistry = ['foo-bar-js', 'foo-bar-js', 'foo-bar-ts'].every((el) => {
@@ -81,14 +70,6 @@ describe('definition-helpers', function () {
       });
 
       expect(hasAllComponentsInRegistry).toEqual(true);
-    });
-  });
-
-  describe('listMUComponents()', function () {
-    it('return expected list of components for mu project', function () {
-      const components = listMUComponents(path.join(__dirname, './../fixtures/mu-project'));
-
-      expect(components.map(({ label }: { label: string }) => label)).toEqual(['foo-bar-js', 'foo-bar-js', 'foo-bar-ts']);
     });
   });
 

--- a/test/utils/layout-helpers-test.ts
+++ b/test/utils/layout-helpers-test.ts
@@ -16,7 +16,6 @@ import * as path from 'path';
 
 import { initFileStructure } from './../test_helpers/integration-helpers';
 import { getRegistryForRoot } from '../../src/utils/registry-api';
-import { Project } from '../../src/project';
 import { BaseProject } from '../../src/base-project';
 
 describe('definition-helpers', function () {
@@ -61,12 +60,13 @@ describe('definition-helpers', function () {
     it('return expected list of components for pods project', function () {
       const root = path.join(__dirname, './../fixtures/pod-project');
 
-      const project = new Project(root);
+      const project = new BaseProject(root);
 
       listPodsComponents(project);
+
       const keys = Object.keys(getRegistryForRoot(root).component);
 
-      const hasAllComponentsInRegistry = ['foo-bar-js', 'foo-bar-js', 'foo-bar-ts'].every((el) => {
+      const hasAllComponentsInRegistry = ['foo-bar-js', 'foo-bar-ts'].every((el) => {
         return keys.includes(el);
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,7 +1426,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x", "@types/jest@^26.0.20":
+"@types/jest@^26.0.20":
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
   integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
@@ -5111,16 +5111,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.memoize@4.x:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
+lodash@4.x, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7112,18 +7107,17 @@ tree-sync@^1.2.2:
     quick-temp "^0.1.5"
     walk-sync "^0.3.3"
 
-ts-jest@^26.4.4:
-  version "26.4.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
-  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+ts-jest@^26.5.6:
+  version "26.5.6"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
+  integrity sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
   dependencies:
-    "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"
     jest-util "^26.1.0"
     json5 "2.x"
-    lodash.memoize "4.x"
+    lodash "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"


### PR DESCRIPTION
unify file path to registry mapping, simplifying logic
removed MU component lookup (open issue if you need it)
resolves: https://github.com/lifeart/ember-language-server/issues/269