### PR TITLE
feat: public asset path go-to definition

### DIFF
--- a/test/__snapshots__/integration-test.ts.snap
+++ b/test/__snapshots__/integration-test.ts.snap
@@ -3184,6 +3184,62 @@ Object {
 }
 `;
 
+exports[`integration async fs enabled: false Go to definition works for all supported cases works for string asset paths in public folder [StringLiteral] 1`] = `
+Object {
+  "addonsMeta": Array [],
+  "registry": Object {
+    "component": Object {
+      "hello": Array [
+        "app/components/hello.hbs",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/public/assets/img.jpg",
+    },
+  ],
+}
+`;
+
+exports[`integration async fs enabled: false Go to definition works for all supported cases works for string asset paths in public folder [TextNode] 1`] = `
+Object {
+  "addonsMeta": Array [],
+  "registry": Object {
+    "component": Object {
+      "hello": Array [
+        "app/components/hello.hbs",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/public/assets/img.jpg",
+    },
+  ],
+}
+`;
+
 exports[`integration async fs enabled: false Initialize request returns an initialize request 1`] = `
 Object {
   "capabilities": Object {
@@ -6733,6 +6789,62 @@ Object {
         },
       },
       "uri": "/app/templates/foo/bar/baz.hbs",
+    },
+  ],
+}
+`;
+
+exports[`integration async fs enabled: true Go to definition works for all supported cases works for string asset paths in public folder [StringLiteral] 1`] = `
+Object {
+  "addonsMeta": Array [],
+  "registry": Object {
+    "component": Object {
+      "hello": Array [
+        "app/components/hello.hbs",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/public/assets/img.jpg",
+    },
+  ],
+}
+`;
+
+exports[`integration async fs enabled: true Go to definition works for all supported cases works for string asset paths in public folder [TextNode] 1`] = `
+Object {
+  "addonsMeta": Array [],
+  "registry": Object {
+    "component": Object {
+      "hello": Array [
+        "app/components/hello.hbs",
+      ],
+    },
+  },
+  "response": Array [
+    Object {
+      "range": Object {
+        "end": Object {
+          "character": 0,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 0,
+        },
+      },
+      "uri": "/public/assets/img.jpg",
     },
   ],
 }

--- a/test/integration-test.ts
+++ b/test/integration-test.ts
@@ -83,6 +83,38 @@ describe('integration', function () {
       });
 
       describe('Go to definition works for all supported cases', () => {
+        it('works for string asset paths in public folder [TextNode]', async () => {
+          const key = 'assets/img.jpg';
+          const entry = 'app/components/hello.hbs';
+          const result = await getResult(
+            DefinitionRequest.method,
+            connection,
+            {
+              [`public/${key}`]: '',
+              [entry]: `<img src="${key}">`,
+            },
+            entry,
+            { line: 0, character: 11 }
+          );
+
+          expect(result).toMatchSnapshot();
+        });
+        it('works for string asset paths in public folder [StringLiteral]', async () => {
+          const key = 'assets/img.jpg';
+          const entry = 'app/components/hello.hbs';
+          const result = await getResult(
+            DefinitionRequest.method,
+            connection,
+            {
+              [`public/${key}`]: '',
+              [entry]: `{{img-src "${key}"}}>`,
+            },
+            entry,
+            { line: 0, character: 12 }
+          );
+
+          expect(result).toMatchSnapshot();
+        });
         it('to to route defintion from LinkTo component', async () => {
           const result = await getResult(
             DefinitionRequest.method,


### PR DESCRIPTION
Adds ability to go to `public` asset by it's path.

Not landing it, because it's unable to show original file (image), once clicked
VSCode does not support binary documents in go-to definition requests resolution