### PR TITLE
fix: key name when translation file is at the root

### DIFF
--- a/src/builtin-addons/core/intl-utils.ts
+++ b/src/builtin-addons/core/intl-utils.ts
@@ -138,10 +138,10 @@ function generateTranslationKey(key: string, filePath: string, root: string): st
 
   const dirname = path
     .dirname(filePath)
-    .replace(new RegExp(`.*\\${path.sep}translations\\${path.sep}`), '')
+    .replace(new RegExp(`.*\\${path.sep}translations(\\${path.sep})?`), '')
     .replace(new RegExp(`\\${path.sep}`, 'g'), '.');
 
-  return `${dirname}.${key}`;
+  return dirname.length ? `${dirname}.${key}` : key;
 }
 
 function addToHashMap(hash: TranslationsHashMap, translationFile: TranslationFile, locale: string, filePath: string, root: string) {

--- a/test/bultin-addons/core/intl-providers-test.ts
+++ b/test/bultin-addons/core/intl-providers-test.ts
@@ -343,6 +343,52 @@ for (const asyncFsEnabled of testCaseAsyncFsOptions) {
             ]);
           });
 
+          it('should autocomplete when the translation is in the root file in handlebars', async () => {
+            expect(
+              (
+                await getResult(
+                  CompletionRequest.method,
+                  connection,
+                  {
+                    app: {
+                      components: {
+                        'test.hbs': `{{t "admin." }}`,
+                      },
+                    },
+                    config: {
+                      'ember-intl.js': `module.exports = function() { return { wrapTranslationsWithNamespace: true } }`,
+                    },
+                    translations: {
+                      'en.yml': `admin:
+  foo: Bar`,
+                    },
+                  },
+                  'app/components/test.hbs',
+                  { line: 0, character: 12 }
+                )
+              ).response
+            ).toEqual([
+              {
+                documentation: 'en : Bar',
+                kind: 12,
+                label: 'admin.foo',
+                textEdit: {
+                  newText: 'admin.foo',
+                  range: {
+                    end: {
+                      character: 7,
+                      line: 0,
+                    },
+                    start: {
+                      character: 7,
+                      line: 0,
+                    },
+                  },
+                },
+              },
+            ]);
+          });
+
           it('should autocomplete in JS files when in the end of expression', async () => {
             expect(
               (


### PR DESCRIPTION
Follow up to the bug found in https://github.com/lifeart/ember-language-server/pull/389#issuecomment-1192553091

Make sure to generate the correct key name when the translation file as at the root translations directory, e.g. `translations/en-us.yml`.

### Before
`.var.folders.mk.5t937px5627_y_j551f8gbkm0000gn.T.tmp-84101gxBh16jwQL7q.translations.admin.countries`

### After
`admin.countries`