### PR TITLE
Fix typos in `yield-context-extractor.ts`

### DIFF
--- a/src/utils/yield-context-extractor.ts
+++ b/src/utils/yield-context-extractor.ts
@@ -70,7 +70,7 @@ export function extractYieldMetadata(template: ASTv1.Template) {
       const acc: Record<string, unknown> = {};
 
       return {
-        $elemant: node.tag,
+        $element: node.tag,
         $attributes: this.map(node.attributes).reduce((acc, [key, val]) => {
           Object.defineProperty(acc, key, {
             value: val,
@@ -79,12 +79,12 @@ export function extractYieldMetadata(template: ASTv1.Template) {
           return acc;
         }, acc),
         $modifiers: this.map(node.modifiers),
-        $programms: this.map(node.children).filter((e) => typeof e !== 'string'),
+        $programs: this.map(node.children).filter((e) => typeof e !== 'string'),
       };
     }
     Template(node: ASTv1.Template | ASTv1.Program) {
       return {
-        $programms: this.map(node.body).filter((e) => typeof e !== 'string'),
+        $programs: this.map(node.body).filter((e) => typeof e !== 'string'),
       };
     }
     ConcatStatement(node: ASTv1.ConcatStatement) {
@@ -137,14 +137,14 @@ export function extractYieldMetadata(template: ASTv1.Template) {
     BlockStatement(node: ASTv1.BlockStatement) {
       const result = this.SubExpression(node);
 
-      const $programms = [this.Block(node.program)];
+      const $programs = [this.Block(node.program)];
 
       if (node.inverse) {
-        $programms.push(this.Block(node.inverse));
+        $programs.push(this.Block(node.inverse));
       }
 
-      Object.defineProperty(result, '$programms', {
-        value: $programms,
+      Object.defineProperty(result, '$programs', {
+        value: $programs,
       });
 
       return result;

--- a/test/utils/yield-context-extractor-test.ts
+++ b/test/utils/yield-context-extractor-test.ts
@@ -5,7 +5,7 @@ function extract(tpl: string) {
   return extractYieldMetadata(preprocess(tpl));
 }
 
-describe('Yeld Metadata API', () => {
+describe('Yield Metadata API', () => {
   it('should handle default yield with hash', () => {
     expect(
       extract(`
@@ -91,7 +91,27 @@ describe('Yeld Metadata API', () => {
       `)
     ).toEqual({ 'default:0:': ['component', 'foo-bar'], 'default:1:': ['component', 'foo-baz'] });
   });
-  it('should handle default yeld with single positional hash argument with component property', () => {
+  it('should handle default yield with single positional hash argument with component property', () => {
     expect(extract(`{{yield (hash Foo=(component "my-component"))}}`)).toEqual({ 'default:0:Foo': ['component', 'my-component'] });
+  });
+  it('should extract only yield content when nested in a div with other content', () => {
+    expect(
+      extract(`
+      <div class="example">
+        <p>Some Content</p>
+        {{yield (hash Foo=(component "my-component"))}}
+      </div>
+      `)
+    ).toEqual({ 'default:0:Foo': ['component', 'my-component'] });
+  });
+
+  it('should extract only yield content when nested in an "if" statement', () => {
+    expect(
+      extract(`
+      {{#if this.isTrue}}
+        {{yield (hash Foo=(component "my-component"))}}
+      {{/if}}
+      `)
+    ).toEqual({ 'default:0:Foo': ['component', 'my-component'] });
   });
 });


### PR DESCRIPTION
Follow up to https://github.com/lifeart/ember-language-server/pull/416 fixing some typos. I added a couple of extra tests that actually hit the `ElementNode` and `BlockStatment` code paths since there wasn't coverage before.


I'm not super familiar with this stuff, but I think we could simplify `ElementNode` a bit. Since an HTML element can't be yielded there isn't really a need to compute their modifiers and attributes. This info never gets used. Please correct me if I'm wrong! Happy to open a PR for that as well